### PR TITLE
Refactor store to support brain reducers

### DIFF
--- a/src/app/store.js
+++ b/src/app/store.js
@@ -1,11 +1,10 @@
 import { configureStore } from '@reduxjs/toolkit';
 import counterReducer from '../features/counter/counterSlice';
-import BrainRootReducer from '../features/chartData/brainRootReducer'
-
-
+import BrainRootReducer from '../features/chartData/brainRootReducer';
 
 export const store = configureStore({
-  counter: counterReducer,
-  reducer: BrainRootReducer,
- // middleware: (getDefaultMiddleware) => getDefaultMiddleware().concat(composeWithDevTools),
-})
+  reducer: {
+    counter: counterReducer,
+    ...BrainRootReducer, // or use combineReducers prior to passing
+  },
+});

--- a/src/features/chartData/brainRootReducer.js
+++ b/src/features/chartData/brainRootReducer.js
@@ -1,11 +1,10 @@
-import { combineReducers } from "redux";
 //import bitcoinReducer from "./bitcoinReducer";
 import brainReducer from "./brainReducer";
 import brainReducer001 from "./brainReducer001";
 
-const rootReducer = combineReducers({
+const BrainRootReducer = {
   brain: brainReducer,
   brain001: brainReducer001,
-})
+};
 
-export default rootReducer;
+export default BrainRootReducer;


### PR DESCRIPTION
## Summary
- spread BrainRootReducer into configureStore to include brain-related slices
- expose BrainRootReducer as a reducer map rather than a combined reducer

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*
- `PYTHON=/usr/bin/python3 npm install` *(fails: build error for gl module)*

------
https://chatgpt.com/codex/tasks/task_e_68a5926efb28832aa28399f21248a62a