### PR TITLE
feat: apply neon tron color scheme

### DIFF
--- a/src/components/chart001.js
+++ b/src/components/chart001.js
@@ -62,7 +62,7 @@ if(chartSize.length >= 2) {chartSize.splice(0, 1)}
     return <div style={{display: 'flexbox', width: '900px', marginTop: '30px'}}>
 
 
-<div style={{width: '900px', backgroundColor: 'rgba(27, 26, 67, 0.27)', borderRadius: '9px'}}>
+<div style={{width: '900px', backgroundColor: 'rgba(10,12,40,0.9)', borderRadius: '9px'}}>
 <Line  data={state.data} options={{responsive: true}}/> 
               <br />
               <button kind='primary' size='2x2' style={{ borderRadius: '9px', marginTop: '25px', marginRight: '12px', marginBottom: '12px'}} onClick={() => setInterval(() => {fetchData("min1")}, 60100)}>⏳START 1 MIN BRAIN CYCLE</button>

--- a/src/features/chartData/brainReducer.js
+++ b/src/features/chartData/brainReducer.js
@@ -22,14 +22,14 @@ const initalState = {
         tention: 0.9,
         label: "OPEN LATESS",
         data: [],
-        backgroundColor: 'rgba(226, 153, 18, 0.9)',
-        borderColor: 'rgba(178, 116, 0, 1)',
-        pointBorderColor: 'rgba(25, 16, 0, 1)',
+        backgroundColor: 'rgba(0, 229, 255, 0.8)',
+        borderColor: 'rgba(0, 179, 209, 1)',
+        pointBorderColor: 'rgba(255,255,255,0.5)',
         options: {
           responsive: true
         }
       }],
-    },  
+    },
   }
   const brainReducer = (state = initalState, action) => {
     const { type, payload } = action;
@@ -60,9 +60,10 @@ const initalState = {
                               label: "OPEN LATESS PRICE",
                               data: payload.open,
                               radius: 1,
-                              backgroundColor: 'rgba(255, 0, 0, 1)',
-                              borderColor: '	rgba(255, 0, 0, 1)',
-                              pointBorderColor: 'rgba(25, 16, 1)',
+                              backgroundColor: 'rgba(0, 229, 255, 0.8)',
+                              borderColor: 'rgba(0, 179, 209, 1)',
+                              pointBorderColor: 'rgba(255,255,255,0.5)',
+                              pointHoverBackgroundColor: 'rgba(255,255,255,0.5)',
                               borderWidth: 0.5,
                               order: 2
                               },
@@ -72,9 +73,10 @@ const initalState = {
                               label: "HIGH LATESS PRICE",
                               data: payload.high, 
                               radius: 1,
-                              backgroundColor:'rgba(0,0,255, 0.7)',
-                              borderColor: 'rgba(0,0,255, 0.9)',
-                              pointBorderColor: 'rgba(0,0,255, 0.8)',    
+                              backgroundColor:'rgba(255, 0, 122, 0.8)',
+                              borderColor: 'rgba(217, 0, 103, 1)',
+                              pointBorderColor: 'rgba(255,255,255,0.5)',
+                              pointHoverBackgroundColor: 'rgba(255,255,255,0.5)',
                               borderWidth: 0.5,             
                               order: 3
                               },
@@ -84,9 +86,10 @@ const initalState = {
                               label: "LOW LATESS PRICE",
                               data: payload.low,
                               radius: 1,
-                              backgroundColor:'rgba(255,255,0, 0.8)',
-                              borderColor: 'rgba(255,255,0, 0.9)',
-                              pointBorderColor: 'rgba(255,255,0, 0.9)',    
+                              backgroundColor:'rgba(0, 255, 137, 0.8)',
+                              borderColor: 'rgba(0, 204, 110, 1)',
+                              pointBorderColor: 'rgba(255,255,255,0.5)',
+                              pointHoverBackgroundColor: 'rgba(255,255,255,0.5)',    
                               borderWidth: 0.5,              
                               order: 4
                               },
@@ -96,9 +99,10 @@ const initalState = {
                               label: "CLOSE LATESS PRICE",
                               data: payload.close,
                               radius: 1,
-                              backgroundColor:'rgba(10, 204, 0, 0.7)',
-                              borderColor: 'rgba(10, 204, 0, 0.9)',
-                              pointBorderColor: 'rgba(10, 204, 0, 0.7)',
+                              backgroundColor:'rgba(173, 0, 255, 0.8)',
+                              borderColor: 'rgba(111, 0, 193, 1)',
+                              pointBorderColor: 'rgba(255,255,255,0.5)',
+                              pointHoverBackgroundColor: 'rgba(255,255,255,0.5)',
                               borderWidth: 0.5,
                               order: 1
                               },
@@ -113,9 +117,9 @@ const initalState = {
                                         label: "OPEN LATESS PRICE",
                                         data: payload.OPlatess,
                                         tention: 0.9,
-                                        backgroundColor: 'rgba(255, 0, 0, 1)',
-                                        borderColor: '	rgba(255, 0, 0, 1)',
-                                        pointBorderColor: 'rgba(25, 16, 1)',
+                                        backgroundColor: 'rgba(0, 229, 255, 0.8)',
+                                        borderColor: 'rgba(0, 179, 209, 1)',
+                                        pointBorderColor: 'rgba(255,255,255,0.5)',
                                         order: 1
                                         },
                                         //AvrOpLatess


### PR DESCRIPTION
## Summary
- adopt neon hues for OPEN/HIGH/LOW/CLOSE datasets with glowing hover accents
- darken chart container to midnight blue for a Tron-like theme

## Testing
- `npm install` *(fails: ModuleNotFoundError: No module named 'distutils')*
- `npm test -- --watchAll=false` *(fails: react-scripts: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a59e6cbc34832aa08e8344be35aa76