### PR TITLE
Correct chart tension properties and labels

### DIFF
--- a/src/components/chart001.js
+++ b/src/components/chart001.js
@@ -10,7 +10,7 @@ import {
   Legend,
 } from 'chart.js';
 import { Line } from 'react-chartjs-2';
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch, useSelector } from 'react-redux';
 import { getData } from '../features/normalizerFactories/btc-usdt';
 
 ChartJS.register(
@@ -20,7 +20,7 @@ ChartJS.register(
   LineElement,
   Title,
   Tooltip,
-  Legend
+  Legend,
 );
 
 export const options = {
@@ -36,52 +36,148 @@ export const options = {
   },
 };
 
-
 export let chartSize = [];
 //////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////
 
 export function ChartI() {
-    const dispatch = useDispatch();
-    const state = useSelector(state => state.brain);
-    const [tickAmount, setTickAmount] = useState(5);
-    chartSize.push(tickAmount);
-if(chartSize.length >= 2) {chartSize.splice(0, 1)}
+  const dispatch = useDispatch();
+  const state = useSelector((state) => state.brain);
+  const [tickAmount, setTickAmount] = useState(5);
+  chartSize.push(tickAmount);
+  if (chartSize.length >= 2) {
+    chartSize.splice(0, 1);
+  }
 
-    const fetchData = (time) => {
-    dispatch(getData({
-       time: time,
-       tickAmount: tickAmount
-    }))
+  const fetchData = (time) => {
+    dispatch(
+      getData({
+        time: time,
+        tickAmount: tickAmount,
+      }),
+    );
     dispatch({
-        type: "SUCCESS_BITCOIN",
-        payload: {},
-        tickAmount
-    })
-}
-    return <div style={{display: 'flexbox', width: '900px', marginTop: '30px'}}>
+      type: 'SUCCESS_BITCOIN',
+      payload: {},
+      tickAmount,
+    });
+  };
+  return (
+    <div style={{ display: 'flexbox', width: '900px', marginTop: '30px' }}>
+      <div
+        style={{
+          width: '900px',
+          backgroundColor: 'rgba(10,12,40,0.9)',
+          borderRadius: '9px',
+        }}
+      >
+        <Line data={state.data} options={{ responsive: true }} />
+        <br />
+        <button
+          kind="primary"
+          size="2x2"
+          style={{
+            borderRadius: '9px',
+            marginTop: '25px',
+            marginRight: '12px',
+            marginBottom: '12px',
+          }}
+          onClick={() =>
+            setInterval(() => {
+              fetchData('min1');
+            }, 60100)
+          }
+        >
+          ⏳START 1 MIN BRAIN CYCLE
+        </button>
+        <button
+          kind="primary"
+          size="2x2"
+          style={{
+            borderRadius: '9px',
+            marginTop: '25px',
+            marginRight: '12px',
+            marginBottom: '12px',
+          }}
+          onClick={() => fetchData('min1')}
+        >
+          START TRAINNING SESSIONS
+        </button>
+        <br />
+      </div>
 
+      <p>{tickAmount}</p>
+      <br />
 
-<div style={{width: '900px', backgroundColor: 'rgba(10,12,40,0.9)', borderRadius: '9px'}}>
-<Line  data={state.data} options={{responsive: true}}/> 
-              <br />
-              <button kind='primary' size='2x2' style={{ borderRadius: '9px', marginTop: '25px', marginRight: '12px', marginBottom: '12px'}} onClick={() => setInterval(() => {fetchData("min1")}, 60100)}>⏳START 1 MIN BRAIN CYCLE</button>
-              <button kind='primary' size='2x2' style={{ borderRadius: '9px', marginTop: '25px', marginRight: '12px', marginBottom: '12px'}} onClick={() => fetchData("min1")}>START TRAINNING SESSIONS</button>
-              <br /> 
-</div>
+      <div style={{ display: 'flexbox', flexDirection: 'row' }}>
+        <button
+          onClick={() => setTickAmount(5)}
+          style={{
+            borderRadius: '9px',
+            marginTop: '25px',
+            marginRight: '12px',
+            width: '60px',
+          }}
+        >
+          5
+        </button>
+        <button
+          onClick={() => setTickAmount(10)}
+          style={{
+            borderRadius: '9px',
+            marginTop: '25px',
+            marginRight: '12px',
+            width: '60px',
+          }}
+        >
+          10
+        </button>
+        <button
+          onClick={() => setTickAmount(15)}
+          style={{
+            borderRadius: '9px',
+            marginTop: '25px',
+            marginRight: '12px',
+            width: '60px',
+          }}
+        >
+          15
+        </button>
+        <button
+          onClick={() => setTickAmount(20)}
+          style={{
+            borderRadius: '9px',
+            marginTop: '25px',
+            marginRight: '12px',
+            width: '60px',
+          }}
+        >
+          20
+        </button>
+        <button
+          onClick={() => setTickAmount(30)}
+          style={{
+            borderRadius: '9px',
+            marginTop: '25px',
+            marginRight: '12px',
+            width: '60px',
+          }}
+        >
+          30
+        </button>
+      </div>
 
-              <p>{tickAmount}</p>
-              <br />
-
-          <div style={{display: 'flexbox', flexDirection: 'row'}}>
-              <button onClick={() => setTickAmount(5)} style={{ borderRadius: '9px', marginTop: '25px', marginRight: '12px', width: '60px'}}>5</button>
-              <button onClick={() => setTickAmount(10)} style={{ borderRadius: '9px', marginTop: '25px', marginRight: '12px', width: '60px'}}>10</button>
-              <button onClick={() => setTickAmount(15)} style={{ borderRadius: '9px', marginTop: '25px', marginRight: '12px', width: '60px'}}>15</button>
-              <button onClick={() => setTickAmount(20)} style={{ borderRadius: '9px', marginTop: '25px', marginRight: '12px', width: '60px'}}>20</button>
-              <button onClick={() => setTickAmount(30)} style={{ borderRadius: '9px', marginTop: '25px', marginRight: '12px', width: '60px'}}>30</button>
-            </div>
-
-                 <button onClick={() => setTickAmount(500)} style={{ borderRadius: '9px', marginTop: '25px', marginRight: '12px', width: '60px'}}>ALL TIME</button>
-    </div>;
-    
+      <button
+        onClick={() => setTickAmount(500)}
+        style={{
+          borderRadius: '9px',
+          marginTop: '25px',
+          marginRight: '12px',
+          width: '60px',
+        }}
+      >
+        ALL TIME
+      </button>
+    </div>
+  );
 }

--- a/src/features/chartData/brainReducer.js
+++ b/src/features/chartData/brainReducer.js
@@ -1,184 +1,192 @@
 const initalState = {
-    Loading: false,
-    data: {
-      labels: [],
-      datasets: [{
+  Loading: false,
+  data: {
+    labels: [],
+    datasets: [
+      {
         type: 'line',
-        tention: 0.9,
-        label: "BOT CHART PREDICTION",
+        tension: 0.9,
+        label: 'BOT CHART PREDICTION',
         data: [],
         backgroundColor: 'rgba(226, 153, 18, 0.9)',
         borderColor: 'rgba(178, 116, 0, 1)',
         pointBorderColor: 'rgba(25, 16, 0, 1)',
         options: {
-          responsive: true
-        }
-      }],
-    }, 
-    dataB: {
-      labels: [],
-      datasets: [{
+          responsive: true,
+        },
+      },
+    ],
+  },
+  dataB: {
+    labels: [],
+    datasets: [
+      {
         type: 'line',
-        tention: 0.9,
-        label: "OPEN LATESS",
+        tension: 0.9,
+        label: 'Open – Latest',
         data: [],
         backgroundColor: 'rgba(0, 229, 255, 0.8)',
         borderColor: 'rgba(0, 179, 209, 1)',
         pointBorderColor: 'rgba(255,255,255,0.5)',
         options: {
-          responsive: true
-        }
-      }],
-    },
-  }
-  const brainReducer = (state = initalState, action) => {
-    const { type, payload } = action;
-  
-    switch (type) {
-        case "AWAITING_BITCOIN":
-          return {
-            ...state,
-            loading: true
-          }
-        case "REJECTED_BITCOIN":
-          return {
-            ...state,
-            loading: false,
-          }
-        case "SUCCESS_BITCOIN":
-  
-            return {
-                ...state,
-                loading: false,
+          responsive: true,
+        },
+      },
+    ],
+  },
+};
+const brainReducer = (state = initalState, action) => {
+  const { type, payload } = action;
 
-                data: {
-                  labels: payload.epoxNum,
-                  text: 'EXPERIMENTAL',
-                  datasets: [
-                            {
-                              type: 'line',
-                              label: "OPEN LATESS PRICE",
-                              data: payload.open,
-                              radius: 1,
-                              backgroundColor: 'rgba(0, 229, 255, 0.8)',
-                              borderColor: 'rgba(0, 179, 209, 1)',
-                              pointBorderColor: 'rgba(255,255,255,0.5)',
-                              pointHoverBackgroundColor: 'rgba(255,255,255,0.5)',
-                              borderWidth: 0.5,
-                              order: 2
-                              },
-  
-                            {
-                              type: 'line',
-                              label: "HIGH LATESS PRICE",
-                              data: payload.high, 
-                              radius: 1,
-                              backgroundColor:'rgba(255, 0, 122, 0.8)',
-                              borderColor: 'rgba(217, 0, 103, 1)',
-                              pointBorderColor: 'rgba(255,255,255,0.5)',
-                              pointHoverBackgroundColor: 'rgba(255,255,255,0.5)',
-                              borderWidth: 0.5,             
-                              order: 3
-                              },
- 
-                            {
-                              type: 'line',
-                              label: "LOW LATESS PRICE",
-                              data: payload.low,
-                              radius: 1,
-                              backgroundColor:'rgba(0, 255, 137, 0.8)',
-                              borderColor: 'rgba(0, 204, 110, 1)',
-                              pointBorderColor: 'rgba(255,255,255,0.5)',
-                              pointHoverBackgroundColor: 'rgba(255,255,255,0.5)',    
-                              borderWidth: 0.5,              
-                              order: 4
-                              },
-           
-                            {
-                              type: 'line',
-                              label: "CLOSE LATESS PRICE",
-                              data: payload.close,
-                              radius: 1,
-                              backgroundColor:'rgba(173, 0, 255, 0.8)',
-                              borderColor: 'rgba(111, 0, 193, 1)',
-                              pointBorderColor: 'rgba(255,255,255,0.5)',
-                              pointHoverBackgroundColor: 'rgba(255,255,255,0.5)',
-                              borderWidth: 0.5,
-                              order: 1
-                              },
-                            ]
-                          },
-                          dataB: {
-                            labels: payload.Epoch,
-                            text: 'EXPERIMENTAL',
-                            datasets: [
-                                      {
-                                        type: 'line',
-                                        label: "OPEN LATESS PRICE",
-                                        data: payload.OPlatess,
-                                        tention: 0.9,
-                                        backgroundColor: 'rgba(0, 229, 255, 0.8)',
-                                        borderColor: 'rgba(0, 179, 209, 1)',
-                                        pointBorderColor: 'rgba(255,255,255,0.5)',
-                                        order: 1
-                                        },
-                                        //AvrOpLatess
-                                        {
-                                          type: 'line',
-                                          label: "OPEN LATESS AVERAGE",
-                                          data: payload.AvrOpLatessSlice,
-                                          tention: 0.9,
-                                          backgroundColor: 'rgba(0, 255, 0, 1)',
-                                          borderColor: '	rgba(0, 255, 0, 1)',
-                                          borderWidth: 1,
-                                          borderDash: [10, 5],
-                                          pointBorderColor: 'rgba(25, 16, 1)',
-                                          order: 2
-                                          },
-                                          //OpBrainResult
-                                          {
-                                            type: 'line',
-                                            pointStyle: 'rectRot',
-                                            label: "LSTM ONE ESTIMATED PRICE VALUE",
-                                            data: payload.OpBrainResltSlice.map((v) => Array.isArray(v) ? v[0] : v),
-                                            tention: 0.9,
-                                            backgroundColor: 'rgba(228, 202, 16, 1)',
-                                            borderColor: 'rgba(248, 104, 21, 1)',
-                                            pointBorderColor: 'rgba(25, 16, 1)',
-                                            borderWidth: 0.75,
-                                            order: 3
-                                            },
-                                           // OpBrainResltSlice002
-                                           {
-                                            type: 'line',
-                                            pointStyle: 'rectRot',
-                                            label: "LSTM TWO ESTIMATED PRICE VALUE",
-                                            data: payload.OpBrainResltSlice002.map((v) => Array.isArray(v) ? v[0] : v),
-                                            tention: 0.9,
-                                            backgroundColor: 'rgba(255, 52, 3, 1)',
-                                            borderColor: 'rgba(255, 52, 3, 1)',
-                                            pointBorderColor: 'rgba(255, 52, 3, 1)',
-                                            borderWidth: 0.75,
-                                            order: 3
-                                            },
-                                            {
-                                              type: 'line',
-                                              pointStyle: 'rectRot',
-                                              label: "LSTM THREE ESTIMATED PRICE VALUE",
-                                              data: payload.OpBrainResltSlice003.map((v) => Array.isArray(v) ? v[0] : v),
-                                              tention: 0.9,
-                                              backgroundColor: 'rgba(255, 52, 90, 1)',
-                                              borderColor: 'rgba(255, 52, 90, 1)',
-                                              pointBorderColor: 'rgba(255, 52, 90, 1)',
-                                              borderWidth: 0.75,
-                                              order: 3
-                                              }
-                                      ]
-                                    },
-                        }
-                        default: return state;
-                      }
-                    }
-              export default brainReducer;
-  
-  
+  switch (type) {
+    case 'AWAITING_BITCOIN':
+      return {
+        ...state,
+        loading: true,
+      };
+    case 'REJECTED_BITCOIN':
+      return {
+        ...state,
+        loading: false,
+      };
+    case 'SUCCESS_BITCOIN':
+      return {
+        ...state,
+        loading: false,
+
+        data: {
+          labels: payload.epoxNum,
+          text: 'EXPERIMENTAL',
+          datasets: [
+            {
+              type: 'line',
+              label: 'Open – Latest Price',
+              data: payload.open,
+              radius: 1,
+              backgroundColor: 'rgba(0, 229, 255, 0.8)',
+              borderColor: 'rgba(0, 179, 209, 1)',
+              pointBorderColor: 'rgba(255,255,255,0.5)',
+              pointHoverBackgroundColor: 'rgba(255,255,255,0.5)',
+              borderWidth: 0.5,
+              order: 2,
+            },
+
+            {
+              type: 'line',
+              label: 'High – Latest Price',
+              data: payload.high,
+              radius: 1,
+              backgroundColor: 'rgba(255, 0, 122, 0.8)',
+              borderColor: 'rgba(217, 0, 103, 1)',
+              pointBorderColor: 'rgba(255,255,255,0.5)',
+              pointHoverBackgroundColor: 'rgba(255,255,255,0.5)',
+              borderWidth: 0.5,
+              order: 3,
+            },
+
+            {
+              type: 'line',
+              label: 'Low – Latest Price',
+              data: payload.low,
+              radius: 1,
+              backgroundColor: 'rgba(0, 255, 137, 0.8)',
+              borderColor: 'rgba(0, 204, 110, 1)',
+              pointBorderColor: 'rgba(255,255,255,0.5)',
+              pointHoverBackgroundColor: 'rgba(255,255,255,0.5)',
+              borderWidth: 0.5,
+              order: 4,
+            },
+
+            {
+              type: 'line',
+              label: 'Close – Latest Price',
+              data: payload.close,
+              radius: 1,
+              backgroundColor: 'rgba(173, 0, 255, 0.8)',
+              borderColor: 'rgba(111, 0, 193, 1)',
+              pointBorderColor: 'rgba(255,255,255,0.5)',
+              pointHoverBackgroundColor: 'rgba(255,255,255,0.5)',
+              borderWidth: 0.5,
+              order: 1,
+            },
+          ],
+        },
+        dataB: {
+          labels: payload.Epoch,
+          text: 'EXPERIMENTAL',
+          datasets: [
+            {
+              type: 'line',
+              label: 'Open – Latest Price',
+              data: payload.OPlatess,
+              tension: 0.9,
+              backgroundColor: 'rgba(0, 229, 255, 0.8)',
+              borderColor: 'rgba(0, 179, 209, 1)',
+              pointBorderColor: 'rgba(255,255,255,0.5)',
+              order: 1,
+            },
+            //AvrOpLatess
+            {
+              type: 'line',
+              label: 'Open – Latest Average',
+              data: payload.AvrOpLatessSlice,
+              tension: 0.9,
+              backgroundColor: 'rgba(0, 255, 0, 1)',
+              borderColor: '	rgba(0, 255, 0, 1)',
+              borderWidth: 1,
+              borderDash: [10, 5],
+              pointBorderColor: 'rgba(25, 16, 1)',
+              order: 2,
+            },
+            //OpBrainResult
+            {
+              type: 'line',
+              pointStyle: 'rectRot',
+              label: 'LSTM ONE ESTIMATED PRICE VALUE',
+              data: payload.OpBrainResltSlice.map((v) =>
+                Array.isArray(v) ? v[0] : v,
+              ),
+              tension: 0.9,
+              backgroundColor: 'rgba(228, 202, 16, 1)',
+              borderColor: 'rgba(248, 104, 21, 1)',
+              pointBorderColor: 'rgba(25, 16, 1)',
+              borderWidth: 0.75,
+              order: 3,
+            },
+            // OpBrainResltSlice002
+            {
+              type: 'line',
+              pointStyle: 'rectRot',
+              label: 'LSTM TWO ESTIMATED PRICE VALUE',
+              data: payload.OpBrainResltSlice002.map((v) =>
+                Array.isArray(v) ? v[0] : v,
+              ),
+              tension: 0.9,
+              backgroundColor: 'rgba(255, 52, 3, 1)',
+              borderColor: 'rgba(255, 52, 3, 1)',
+              pointBorderColor: 'rgba(255, 52, 3, 1)',
+              borderWidth: 0.75,
+              order: 3,
+            },
+            {
+              type: 'line',
+              pointStyle: 'rectRot',
+              label: 'LSTM THREE ESTIMATED PRICE VALUE',
+              data: payload.OpBrainResltSlice003.map((v) =>
+                Array.isArray(v) ? v[0] : v,
+              ),
+              tension: 0.9,
+              backgroundColor: 'rgba(255, 52, 90, 1)',
+              borderColor: 'rgba(255, 52, 90, 1)',
+              pointBorderColor: 'rgba(255, 52, 90, 1)',
+              borderWidth: 0.75,
+              order: 3,
+            },
+          ],
+        },
+      };
+    default:
+      return state;
+  }
+};
+export default brainReducer;

--- a/src/features/chartData/brainReducer001.js
+++ b/src/features/chartData/brainReducer001.js
@@ -1,63 +1,64 @@
 const initalState = {
-    Loading: false,
-    dataC: {
-      labels: [],
-      datasets: [{
+  Loading: false,
+  dataC: {
+    labels: [],
+    datasets: [
+      {
         type: 'bar',
-        tention: 0.9,
-        label: "BOT CHART PREDICTION",
+        tension: 0.9,
+        label: 'BOT CHART PREDICTION',
         data: [],
         backgroundColor: 'rgba(226, 153, 18, 0.9)',
         borderColor: 'rgba(178, 116, 0, 1)',
         pointBorderColor: 'rgba(25, 16, 0, 1)',
         options: {
-          responsive: true
-        }
-      }],
-    },   
+          responsive: true,
+        },
+      },
+    ],
+  },
+};
+const brainReducer = (state = initalState, action) => {
+  const { type, payload } = action;
+
+  switch (type) {
+    case 'AWAITING_BITCOIN':
+      return {
+        ...state,
+        loading: true,
+      };
+    case 'REJECTED_BITCOIN':
+      return {
+        ...state,
+        loading: false,
+      };
+    case 'SUCCESS_BITCOIN':
+      return {
+        ...state,
+        loading: false,
+
+        dataC: {
+          labels: payload.Epoch,
+          text: 'EXPERIMENTAL',
+          datasets: [
+            {
+              type: 'bar',
+              label: 'MESUREMENT',
+              data: payload.brainMesurementSlice001.map((v) =>
+                Array.isArray(v) ? v[0] : v,
+              ),
+              radius: 1,
+              backgroundColor: payload.brMesurementSliceColor001,
+              borderColor: payload.brMesurementSliceColor001,
+              pointBorderColor: payload.brMesurementSliceColor001,
+              borderWidth: 0.5,
+              order: 2,
+            },
+          ],
+        },
+      };
+    default:
+      return state;
   }
-  const brainReducer = (state = initalState, action) => {
-    const { type, payload } = action;
-  
-    switch (type) {
-        case "AWAITING_BITCOIN":
-          return {
-            ...state,
-            loading: true
-          }
-        case "REJECTED_BITCOIN":
-          return {
-            ...state,
-            loading: false,
-          }
-        case "SUCCESS_BITCOIN":
-  
-            return {
-                ...state,
-                loading: false,
-
-                dataC: {
-                  labels: payload.Epoch,
-                  text: 'EXPERIMENTAL',
-                  datasets: [
-                            {
-                              type: 'bar',
-                              label: "MESUREMENT",
-                              data: payload.brainMesurementSlice001.map((v) => Array.isArray(v) ? v[0] : v),
-                              radius: 1,
-                              backgroundColor: payload.brMesurementSliceColor001,
-                              borderColor: payload.brMesurementSliceColor001,
-                              pointBorderColor: payload.brMesurementSliceColor001,
-                              borderWidth: 0.5,
-                              order: 2
-                              },
-
-                            ]
-                          },
-                        }
-                        default: return state;
-                      }
-                    }
-              export default brainReducer;
-  
-  
+};
+export default brainReducer;


### PR DESCRIPTION
## Summary
- rename `tention` to `tension` in chart reducers
- standardize dataset labels such as "Open – Latest Price"
- clarify marginBottom styles for chart buttons

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6391970c8832a84cee93335f63d74