### PR TITLE
refactor: move chart constants to settings module

### DIFF
--- a/src/components/chart001.js
+++ b/src/components/chart001.js
@@ -12,6 +12,7 @@ import {
 import { Line } from 'react-chartjs-2';
 import { useDispatch, useSelector } from 'react-redux';
 import { getData } from '../features/normalizerFactories/btc-usdt';
+import { chartSize } from '../features/chartSettings';
 
 ChartJS.register(
   CategoryScale,
@@ -35,10 +36,6 @@ export const options = {
     },
   },
 };
-
-export let chartSize = [];
-//////////////////////////////////////////////////////////////////////
-///////////////////////////////////////////////////////////////////////
 
 export function ChartI() {
   const dispatch = useDispatch();

--- a/src/features/chartSettings.js
+++ b/src/features/chartSettings.js
@@ -1,0 +1,3 @@
+export let chartSize = [];
+
+// Additional UI-only data settings can be placed here in the future.

--- a/src/features/normalizerFactories/btc-usdt.js
+++ b/src/features/normalizerFactories/btc-usdt.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { chartSize } from '../../components/chart001';
+import { chartSize } from '../chartSettings';
 const brain = require('brain.js');
 
 const createConfig = (activation = 'tanh', overrides = {}) => ({


### PR DESCRIPTION
## Summary
- centralize chartSize in new features/chartSettings module
- update chart component and btc-usdt normalizer to import chartSize from settings

## Testing
- `pnpm lint`
- `pnpm test run`


------
https://chatgpt.com/codex/tasks/task_e_68a647c21c58832a98f723f7a2711305