### PR TITLE
Add brain state slice and update store

### DIFF
--- a/src/app/store.js
+++ b/src/app/store.js
@@ -1,10 +1,10 @@
 import { configureStore } from '@reduxjs/toolkit';
 import counterReducer from '../features/counter/counterSlice';
-import BrainRootReducer from '../features/chartData/brainRootReducer';
+import brainReducer from '../features/brain/brainSlice';
 
 export const store = configureStore({
   reducer: {
     counter: counterReducer,
-    ...BrainRootReducer, // or use combineReducers prior to passing
+    brain: brainReducer,
   },
 });

--- a/src/features/brain/brainSlice.js
+++ b/src/features/brain/brainSlice.js
@@ -1,0 +1,42 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const initialState = {
+  status: 'idle',
+  hyperparams: {},
+  predictions: {
+    labels: [],
+    values: [],
+  },
+  metrics: {
+    labels: [],
+    values: [],
+  },
+};
+
+const brainSlice = createSlice({
+  name: 'brain',
+  initialState,
+  reducers: {
+    setHyperparams(state, action) {
+      state.hyperparams = action.payload;
+    },
+    setPredictions(state, action) {
+      const { labels = [], values = [] } = action.payload || {};
+      state.predictions.labels = labels;
+      state.predictions.values = values;
+    },
+    setMetrics(state, action) {
+      const { labels = [], values = [] } = action.payload || {};
+      state.metrics.labels = labels;
+      state.metrics.values = values;
+    },
+    setStatus(state, action) {
+      state.status = action.payload;
+    },
+  },
+});
+
+export const { setHyperparams, setPredictions, setMetrics, setStatus } =
+  brainSlice.actions;
+
+export default brainSlice.reducer;


### PR DESCRIPTION
## Summary
- add `brainSlice` with status, hyperparams, predictions, and metrics
- wire new `brain` reducer into the Redux store

## Testing
- `pnpm lint`
- `pnpm test --run`


------
https://chatgpt.com/codex/tasks/task_e_68a65504368c832aa0381d4c6de275cf