### PR TITLE
Refactor charts with shared config and dataset helpers

### DIFF
--- a/src/charts/config.ts
+++ b/src/charts/config.ts
@@ -1,0 +1,31 @@
+export const chartOptions = {
+  responsive: true,
+  plugins: {
+    tooltip: {
+      enabled: true,
+    },
+    zoom: {
+      pan: {
+        enabled: true,
+        mode: 'x',
+      },
+      zoom: {
+        wheel: {
+          enabled: true,
+        },
+        pinch: {
+          enabled: true,
+        },
+        mode: 'x',
+      },
+    },
+  },
+  scales: {
+    x: {
+      type: 'time',
+      time: {
+        unit: 'minute',
+      },
+    },
+  },
+};

--- a/src/charts/datasets.ts
+++ b/src/charts/datasets.ts
@@ -1,0 +1,29 @@
+export function lineDataset(
+  data: number[],
+  label: string,
+  borderColor: string,
+  backgroundColor?: string,
+) {
+  return {
+    type: 'line' as const,
+    label,
+    data,
+    borderColor,
+    backgroundColor: backgroundColor ?? borderColor,
+    tension: 0.1,
+  };
+}
+
+export function barDataset(
+  data: number[],
+  label: string,
+  backgroundColor: string | string[],
+) {
+  return {
+    type: 'bar' as const,
+    label,
+    data,
+    backgroundColor,
+    borderColor: backgroundColor,
+  };
+}

--- a/src/components/chart001.js
+++ b/src/components/chart001.js
@@ -3,6 +3,7 @@ import {
   Chart as ChartJS,
   CategoryScale,
   LinearScale,
+  TimeScale,
   PointElement,
   LineElement,
   Title,
@@ -13,29 +14,19 @@ import { Line } from 'react-chartjs-2';
 import { useDispatch, useSelector } from 'react-redux';
 import { getData } from '../features/normalizerFactories/btc-usdt';
 import { chartSize } from '../features/chartSettings';
+import { chartOptions } from '../charts/config';
+import { lineDataset } from '../charts/datasets';
 
 ChartJS.register(
   CategoryScale,
   LinearScale,
+  TimeScale,
   PointElement,
   LineElement,
   Title,
   Tooltip,
   Legend,
 );
-
-export const options = {
-  responsive: true,
-  plugins: {
-    legend: {
-      position: 'top',
-    },
-    title: {
-      display: true,
-      text: 'Chart.js Random Line Chart on refresh...',
-    },
-  },
-};
 
 export function ChartI() {
   const dispatch = useDispatch();
@@ -59,6 +50,14 @@ export function ChartI() {
       tickAmount,
     });
   };
+
+  const data = {
+    labels: state.data.labels,
+    datasets: state.data.datasets.map((ds) =>
+      lineDataset(ds.data, ds.label, ds.borderColor, ds.backgroundColor),
+    ),
+  };
+
   return (
     <div style={{ display: 'flexbox', width: '900px', marginTop: '30px' }}>
       <div
@@ -68,7 +67,7 @@ export function ChartI() {
           borderRadius: '9px',
         }}
       >
-        <Line data={state.data} options={{ responsive: true }} />
+        <Line data={data} options={chartOptions} />
         <br />
         <button
           kind="primary"

--- a/src/components/chart002.js
+++ b/src/components/chart002.js
@@ -3,6 +3,7 @@ import {
   Chart as ChartJS,
   CategoryScale,
   LinearScale,
+  TimeScale,
   PointElement,
   LineElement,
   Title,
@@ -10,59 +11,56 @@ import {
   Legend,
 } from 'chart.js';
 import { Line } from 'react-chartjs-2';
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch, useSelector } from 'react-redux';
 import { getData } from '../features/normalizerFactories/btc-usdt';
+import { chartOptions } from '../charts/config';
+import { lineDataset } from '../charts/datasets';
 
 ChartJS.register(
   CategoryScale,
   LinearScale,
+  TimeScale,
   PointElement,
   LineElement,
   Title,
   Tooltip,
-  Legend
+  Legend,
 );
-
-export const options = {
-  responsive: true,
-  plugins: {
-    legend: {
-      position: 'top',
-    },
-    title: {
-      display: true,
-      text: 'Chart.js Random Line Chart on refresh...',
-    },
-  },
-};
-
-
 
 //////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////
 
 export function ChartII() {
-    const dispatch = useDispatch();
-    const state = useSelector(state => state.brain);
-   // const [tickAmount, setTickAmount] = useState(5);
+  const dispatch = useDispatch();
+  const state = useSelector((state) => state.brain);
+  // const [tickAmount, setTickAmount] = useState(5);
 
-    const fetchData = (time) => {
-    dispatch(getData({
-       time: time,
-    }))
+  const fetchData = (time) => {
+    dispatch(
+      getData({
+        time: time,
+      }),
+    );
     dispatch({
-        type: "SUCCESS_BITCOIN",
-        payload: {},
+      type: 'SUCCESS_BITCOIN',
+      payload: {},
+    });
+  };
 
-    })
-}
+  const data = {
+    labels: state.dataB.labels,
+    datasets: state.dataB.datasets.map((ds) =>
+      lineDataset(ds.data, ds.label, ds.borderColor, ds.backgroundColor),
+    ),
+  };
 
-    return <div style={{display: 'flexbox', width: '900px'}} onChange={() => fetchData("min1")}>
-
-              <Line data={state.dataB} options={{responsive: true}}/> 
-              <br />
-
-
-    </div>;
-    
+  return (
+    <div
+      style={{ display: 'flexbox', width: '900px' }}
+      onChange={() => fetchData('min1')}
+    >
+      <Line data={data} options={chartOptions} />
+      <br />
+    </div>
+  );
 }

--- a/src/components/chart003.js
+++ b/src/components/chart003.js
@@ -3,6 +3,7 @@ import {
   Chart as ChartJS,
   CategoryScale,
   LinearScale,
+  TimeScale,
   PointElement,
   LineElement,
   BarElement,
@@ -12,60 +13,57 @@ import {
 } from 'chart.js';
 //import { Line } from 'react-chartjs-2';
 import { Bar } from 'react-chartjs-2';
-import { useDispatch, useSelector } from "react-redux";
+import { useDispatch, useSelector } from 'react-redux';
 import { getData } from '../features/normalizerFactories/btc-usdt';
+import { chartOptions } from '../charts/config';
+import { barDataset } from '../charts/datasets';
 
 ChartJS.register(
   CategoryScale,
   LinearScale,
+  TimeScale,
   PointElement,
   LineElement,
   BarElement,
   Title,
   Tooltip,
-  Legend
+  Legend,
 );
-
-export const options = {
-  responsive: true,
-  plugins: {
-    legend: {
-      position: 'top',
-    },
-    title: {
-      display: true,
-      text: 'Chart.js Random Line Chart on refresh...',
-    },
-  },
-};
-
-
 
 //////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////
 
 export function ChartIII() {
-    const dispatch = useDispatch();
-    const state = useSelector(state => state.brain001);
-   // const [tickAmount, setTickAmount] = useState(5);
+  const dispatch = useDispatch();
+  const state = useSelector((state) => state.brain001);
+  // const [tickAmount, setTickAmount] = useState(5);
 
-    const fetchData = (time) => {
-    dispatch(getData({
-       time: time,
-    }))
+  const fetchData = (time) => {
+    dispatch(
+      getData({
+        time: time,
+      }),
+    );
     dispatch({
-        type: "SUCCESS_BITCOIN",
-        payload: {},
+      type: 'SUCCESS_BITCOIN',
+      payload: {},
+    });
+  };
 
-    })
-}
+  const data = {
+    labels: state.dataC.labels,
+    datasets: state.dataC.datasets.map((ds) =>
+      barDataset(ds.data, ds.label, ds.backgroundColor),
+    ),
+  };
 
-    return <div style={{display: 'flexbox', width: '900px'}} onChange={() => fetchData("min1")}>
-
-              <Bar data={state.dataC} options={{responsive: true}}/> 
-              <br />
-
-
-    </div>;
-    
+  return (
+    <div
+      style={{ display: 'flexbox', width: '900px' }}
+      onChange={() => fetchData('min1')}
+    >
+      <Bar data={data} options={chartOptions} />
+      <br />
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- add reusable Chart.js configuration with tooltip, zoom and time scale
- add helpers to build line and bar datasets from raw arrays
- refactor chart001, chart002 and chart003 to use shared options and dataset helpers

## Testing
- `pnpm lint`
- `pnpm vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68a6648597bc832aa68a48da6f8c8baf