### PR TITLE
feat: add market API slice and use RTK Query hooks

### DIFF
--- a/src/app/store.js
+++ b/src/app/store.js
@@ -1,10 +1,14 @@
 import { configureStore } from '@reduxjs/toolkit';
 import counterReducer from '../features/counter/counterSlice';
 import brainReducer from '../features/brain/brainSlice';
+import { marketApi } from '../features/markets/marketApi';
 
 export const store = configureStore({
   reducer: {
     counter: counterReducer,
     brain: brainReducer,
+    [marketApi.reducerPath]: marketApi.reducer,
   },
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware().concat(marketApi.middleware),
 });

--- a/src/components/chart001.js
+++ b/src/components/chart001.js
@@ -11,8 +11,8 @@ import {
   Legend,
 } from 'chart.js';
 import { Line } from 'react-chartjs-2';
-import { useDispatch, useSelector } from 'react-redux';
-import { getData } from '../features/normalizerFactories/btc-usdt';
+import { useSelector } from 'react-redux';
+import { useGetOhlcQuery } from '../features/markets/marketApi';
 import { chartSize } from '../features/chartSettings';
 import { chartOptions } from '../charts/config';
 import { lineDataset } from '../charts/datasets';
@@ -29,7 +29,6 @@ ChartJS.register(
 );
 
 export function ChartI() {
-  const dispatch = useDispatch();
   const state = useSelector((state) => state.brain);
   const [tickAmount, setTickAmount] = useState(5);
   chartSize.push(tickAmount);
@@ -37,18 +36,9 @@ export function ChartI() {
     chartSize.splice(0, 1);
   }
 
-  const fetchData = (time) => {
-    dispatch(
-      getData({
-        time: time,
-        tickAmount: tickAmount,
-      }),
-    );
-    dispatch({
-      type: 'SUCCESS_BITCOIN',
-      payload: {},
-      tickAmount,
-    });
+  const { refetch } = useGetOhlcQuery({ symbol: 'BTCUSDT', interval: '1m' });
+  const fetchData = () => {
+    refetch();
   };
 
   const data = {
@@ -80,7 +70,7 @@ export function ChartI() {
           }}
           onClick={() =>
             setInterval(() => {
-              fetchData('min1');
+              fetchData();
             }, 60100)
           }
         >
@@ -95,7 +85,7 @@ export function ChartI() {
             marginRight: '12px',
             marginBottom: '12px',
           }}
-          onClick={() => fetchData('min1')}
+          onClick={() => fetchData()}
         >
           START TRAINNING SESSIONS
         </button>

--- a/src/components/chart002.js
+++ b/src/components/chart002.js
@@ -11,8 +11,8 @@ import {
   Legend,
 } from 'chart.js';
 import { Line } from 'react-chartjs-2';
-import { useDispatch, useSelector } from 'react-redux';
-import { getData } from '../features/normalizerFactories/btc-usdt';
+import { useSelector } from 'react-redux';
+import { useGetOhlcQuery } from '../features/markets/marketApi';
 import { chartOptions } from '../charts/config';
 import { lineDataset } from '../charts/datasets';
 
@@ -31,21 +31,8 @@ ChartJS.register(
 ///////////////////////////////////////////////////////////////////////
 
 export function ChartII() {
-  const dispatch = useDispatch();
   const state = useSelector((state) => state.brain);
-  // const [tickAmount, setTickAmount] = useState(5);
-
-  const fetchData = (time) => {
-    dispatch(
-      getData({
-        time: time,
-      }),
-    );
-    dispatch({
-      type: 'SUCCESS_BITCOIN',
-      payload: {},
-    });
-  };
+  useGetOhlcQuery({ symbol: 'BTCUSDT', interval: '1m' });
 
   const data = {
     labels: state.dataB.labels,
@@ -55,10 +42,7 @@ export function ChartII() {
   };
 
   return (
-    <div
-      style={{ display: 'flexbox', width: '900px' }}
-      onChange={() => fetchData('min1')}
-    >
+    <div style={{ display: 'flexbox', width: '900px' }}>
       <Line data={data} options={chartOptions} />
       <br />
     </div>

--- a/src/components/chart003.js
+++ b/src/components/chart003.js
@@ -13,8 +13,8 @@ import {
 } from 'chart.js';
 //import { Line } from 'react-chartjs-2';
 import { Bar } from 'react-chartjs-2';
-import { useDispatch, useSelector } from 'react-redux';
-import { getData } from '../features/normalizerFactories/btc-usdt';
+import { useSelector } from 'react-redux';
+import { useGetOhlcQuery } from '../features/markets/marketApi';
 import { chartOptions } from '../charts/config';
 import { barDataset } from '../charts/datasets';
 
@@ -34,21 +34,8 @@ ChartJS.register(
 ///////////////////////////////////////////////////////////////////////
 
 export function ChartIII() {
-  const dispatch = useDispatch();
   const state = useSelector((state) => state.brain001);
-  // const [tickAmount, setTickAmount] = useState(5);
-
-  const fetchData = (time) => {
-    dispatch(
-      getData({
-        time: time,
-      }),
-    );
-    dispatch({
-      type: 'SUCCESS_BITCOIN',
-      payload: {},
-    });
-  };
+  useGetOhlcQuery({ symbol: 'BTCUSDT', interval: '1m' });
 
   const data = {
     labels: state.dataC.labels,
@@ -58,10 +45,7 @@ export function ChartIII() {
   };
 
   return (
-    <div
-      style={{ display: 'flexbox', width: '900px' }}
-      onChange={() => fetchData('min1')}
-    >
+    <div style={{ display: 'flexbox', width: '900px' }}>
       <Bar data={data} options={chartOptions} />
       <br />
     </div>

--- a/src/features/markets/marketApi.ts
+++ b/src/features/markets/marketApi.ts
@@ -1,0 +1,18 @@
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+
+export const marketApi = createApi({
+  reducerPath: 'marketApi',
+  baseQuery: fetchBaseQuery({ baseUrl: 'https://api.binance.com/api/v3/' }),
+  endpoints: (builder) => ({
+    getOhlc: builder.query<any, { symbol?: string; interval?: string }>({
+      query: ({ symbol = 'BTCUSDT', interval = '1m' } = {}) =>
+        `klines?symbol=${symbol}&interval=${interval}`,
+    }),
+    getTicker: builder.query<any, { symbol?: string }>({
+      query: ({ symbol = 'BTCUSDT' } = {}) =>
+        `ticker/24hr?symbol=${symbol}`,
+    }),
+  }),
+});
+
+export const { useGetOhlcQuery, useGetTickerQuery } = marketApi;


### PR DESCRIPTION
## Summary
- set up RTK Query `marketApi` for Binance OHLC and ticker endpoints
- register API reducer and middleware in the Redux store
- replace `getData` calls in chart components with `useGetOhlcQuery`

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a66f67ad38832a9444e06f03ca29e5