### PR TITLE
feat: add brain training worker and thunk

### DIFF
--- a/src/features/brain/brainSlice.js
+++ b/src/features/brain/brainSlice.js
@@ -11,6 +11,8 @@ const initialState = {
     labels: [],
     values: [],
   },
+  modelJSON: null,
+  norm: null,
 };
 
 const brainSlice = createSlice({
@@ -33,10 +35,20 @@ const brainSlice = createSlice({
     setStatus(state, action) {
       state.status = action.payload;
     },
+    setModel(state, action) {
+      const { modelJSON = null, norm = null } = action.payload || {};
+      state.modelJSON = modelJSON;
+      state.norm = norm;
+    },
   },
 });
 
-export const { setHyperparams, setPredictions, setMetrics, setStatus } =
-  brainSlice.actions;
+export const {
+  setHyperparams,
+  setPredictions,
+  setMetrics,
+  setStatus,
+  setModel,
+} = brainSlice.actions;
 
 export default brainSlice.reducer;

--- a/src/features/brain/brainThunks.js
+++ b/src/features/brain/brainThunks.js
@@ -1,0 +1,44 @@
+import { setMetrics, setModel, setStatus } from './brainSlice';
+
+// Thunk to kick off training in a web worker and funnel progress back into
+// redux state.  It expects an object containing `{ series, hyperparams, norm }`.
+// Progress messages from the worker are stored under `metrics` where the
+// iteration number becomes the label and the error the value.
+
+export const startTraining = ({ series = [], hyperparams = {}, norm = null }) =>
+  (dispatch, getState) => {
+    const worker = new Worker(
+      new URL('../../workers/trainBrain.worker.js', import.meta.url),
+      { type: 'module' }
+    );
+
+    dispatch(setStatus('training'));
+
+    worker.onmessage = ({ data }) => {
+      const { progress, done, error } = data || {};
+
+      if (typeof progress !== 'undefined') {
+        const { metrics } = getState().brain;
+        dispatch(
+          setMetrics({
+            labels: [...metrics.labels, metrics.labels.length + 1],
+            values: [...metrics.values, progress],
+          })
+        );
+      }
+
+      if (done) {
+        dispatch(setModel({ modelJSON: done.modelJSON, norm: done.norm }));
+        dispatch(setStatus('idle'));
+        worker.terminate();
+      }
+
+      if (error) {
+        dispatch(setStatus('error'));
+        worker.terminate();
+      }
+    };
+
+    worker.postMessage({ series, hyperparams, norm });
+  };
+

--- a/src/workers/trainBrain.worker.js
+++ b/src/workers/trainBrain.worker.js
@@ -1,0 +1,28 @@
+import brain from 'brain.js';
+
+// Web worker responsible for training a brain.js network.
+// It expects to receive a message containing:
+//   { series, hyperparams, norm }
+// and will respond with progress updates via `{ progress }` as training
+// occurs.  When training finishes a `{ done: { modelJSON, norm } }` message
+// is emitted.  If an error occurs a `{ error }` message is sent instead.
+
+self.onmessage = function ({ data }) {
+  const { series = [], hyperparams = {}, norm = null } = data || {};
+
+  try {
+    const net = new brain.recurrent.LSTMTimeStep(hyperparams);
+
+    net.train(series, {
+      ...hyperparams,
+      // Forward any training progress to the main thread
+      log: (error) => self.postMessage({ progress: error }),
+    });
+
+    const modelJSON = net.toJSON();
+    self.postMessage({ done: { modelJSON, norm } });
+  } catch (err) {
+    self.postMessage({ error: err?.message || String(err) });
+  }
+};
+


### PR DESCRIPTION
## Summary
- add web worker to train brain.js models and report progress
- add `startTraining` thunk to manage training lifecycle
- persist model JSON and normalization params in brain slice

## Testing
- `pnpm test --run`

------
https://chatgpt.com/codex/tasks/task_e_68a672be9e58832a996c894389dc4134