### PR TITLE
Add memoized selectors for chart series

### DIFF
--- a/src/components/chart001.js
+++ b/src/components/chart001.js
@@ -16,6 +16,7 @@ import { useGetOhlcQuery } from '../features/markets/marketApi';
 import { chartSize } from '../features/chartSettings';
 import { chartOptions } from '../charts/config';
 import { lineDataset } from '../charts/datasets';
+import { selectPredictionSeries } from '../selectors/seriesSelectors';
 
 ChartJS.register(
   CategoryScale,
@@ -29,7 +30,7 @@ ChartJS.register(
 );
 
 export function ChartI() {
-  const state = useSelector((state) => state.brain);
+  const { labels, values } = useSelector(selectPredictionSeries);
   const [tickAmount, setTickAmount] = useState(5);
   chartSize.push(tickAmount);
   if (chartSize.length >= 2) {
@@ -42,10 +43,8 @@ export function ChartI() {
   };
 
   const data = {
-    labels: state.data.labels,
-    datasets: state.data.datasets.map((ds) =>
-      lineDataset(ds.data, ds.label, ds.borderColor, ds.backgroundColor),
-    ),
+    labels,
+    datasets: [lineDataset(values, 'Predictions', 'rgba(226, 153, 18, 0.9)')],
   };
 
   return (

--- a/src/components/chart002.js
+++ b/src/components/chart002.js
@@ -15,6 +15,7 @@ import { useSelector } from 'react-redux';
 import { useGetOhlcQuery } from '../features/markets/marketApi';
 import { chartOptions } from '../charts/config';
 import { lineDataset } from '../charts/datasets';
+import { selectMetricSeries } from '../selectors/seriesSelectors';
 
 ChartJS.register(
   CategoryScale,
@@ -31,14 +32,12 @@ ChartJS.register(
 ///////////////////////////////////////////////////////////////////////
 
 export function ChartII() {
-  const state = useSelector((state) => state.brain);
+  const { labels, values } = useSelector(selectMetricSeries);
   useGetOhlcQuery({ symbol: 'BTCUSDT', interval: '1m' });
 
   const data = {
-    labels: state.dataB.labels,
-    datasets: state.dataB.datasets.map((ds) =>
-      lineDataset(ds.data, ds.label, ds.borderColor, ds.backgroundColor),
-    ),
+    labels,
+    datasets: [lineDataset(values, 'Metrics', 'rgba(0, 179, 209, 1)')],
   };
 
   return (

--- a/src/components/chart003.js
+++ b/src/components/chart003.js
@@ -17,6 +17,7 @@ import { useSelector } from 'react-redux';
 import { useGetOhlcQuery } from '../features/markets/marketApi';
 import { chartOptions } from '../charts/config';
 import { barDataset } from '../charts/datasets';
+import { selectMetricSeries } from '../selectors/seriesSelectors';
 
 ChartJS.register(
   CategoryScale,
@@ -34,14 +35,12 @@ ChartJS.register(
 ///////////////////////////////////////////////////////////////////////
 
 export function ChartIII() {
-  const state = useSelector((state) => state.brain001);
+  const { labels, values } = useSelector(selectMetricSeries);
   useGetOhlcQuery({ symbol: 'BTCUSDT', interval: '1m' });
 
   const data = {
-    labels: state.dataC.labels,
-    datasets: state.dataC.datasets.map((ds) =>
-      barDataset(ds.data, ds.label, ds.backgroundColor),
-    ),
+    labels,
+    datasets: [barDataset(values, 'Metrics', 'rgba(226, 153, 18, 0.9)')],
   };
 
   return (

--- a/src/selectors/seriesSelectors.js
+++ b/src/selectors/seriesSelectors.js
@@ -1,0 +1,16 @@
+import { createSelector } from '@reduxjs/toolkit';
+
+const toArray = (series) => (Array.isArray(series) ? series : Object.values(series || {}));
+
+const selectPredictions = (state) => state.brain.predictions;
+const selectMetrics = (state) => state.brain.metrics;
+
+export const selectPredictionSeries = createSelector([selectPredictions], ({ labels = [], values = [] }) => ({
+  labels: toArray(labels),
+  values: toArray(values),
+}));
+
+export const selectMetricSeries = createSelector([selectMetrics], ({ labels = [], values = [] }) => ({
+  labels: toArray(labels),
+  values: toArray(values),
+}));


### PR DESCRIPTION
## Summary
- add memoized selectors converting brain series state into chart-ready arrays
- update chart components to use selectors with dataset helpers

## Testing
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68a6743b62d8832a92024a8e91523dd7