### PR TITLE
feat: add app shell and routing

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "react-chartjs-2": "^4.3.1",
     "react-dom": "^18.2.0",
     "react-redux": "^8.0.5",
+    "react-router-dom": "6",
     "redux-devtools-extension": "^2.13.9",
     "web-vitals": "^2.1.4"
   },
@@ -36,12 +37,12 @@
     ]
   },
   "devDependencies": {
+    "@eslint/js": "^8.57.0",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.0.0",
     "@vitejs/plugin-react-swc": "^3.0.0",
-    "@eslint/js": "^8.57.0",
     "eslint": "^8.57.0",
     "eslint-plugin-react": "^7.33.2",
     "globals": "^15.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,9 @@ importers:
       react-redux:
         specifier: ^8.0.5
         version: 8.1.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@4.2.1)
+      react-router-dom:
+        specifier: '6'
+        version: 6.30.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       redux-devtools-extension:
         specifier: ^2.13.9
         version: 2.13.9(redux@4.2.1)
@@ -465,6 +468,13 @@ packages:
         optional: true
       react-redux:
         optional: true
+
+  '@remix-run/router@1.23.0':
+    resolution:
+      {
+        integrity: sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==,
+      }
+    engines: { node: '>=14.0.0' }
 
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution:
@@ -3162,6 +3172,25 @@ packages:
       redux:
         optional: true
 
+  react-router-dom@6.30.1:
+    resolution:
+      {
+        integrity: sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==,
+      }
+    engines: { node: '>=14.0.0' }
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+
+  react-router@6.30.1:
+    resolution:
+      {
+        integrity: sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==,
+      }
+    engines: { node: '>=14.0.0' }
+    peerDependencies:
+      react: '>=16.8'
+
   react@18.3.1:
     resolution:
       {
@@ -4243,6 +4272,8 @@ snapshots:
     optionalDependencies:
       react: 18.3.1
       react-redux: 8.1.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@4.2.1)
+
+  '@remix-run/router@1.23.0': {}
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
@@ -6006,6 +6037,18 @@ snapshots:
       '@types/react-dom': 18.3.7(@types/react@18.3.23)
       react-dom: 18.3.1(react@18.3.1)
       redux: 4.2.1
+
+  react-router-dom@6.30.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@remix-run/router': 1.23.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-router: 6.30.1(react@18.3.1)
+
+  react-router@6.30.1(react@18.3.1):
+    dependencies:
+      '@remix-run/router': 1.23.0
+      react: 18.3.1
 
   react@18.3.1:
     dependencies:

--- a/src/components/AppShell/AppShell.tsx
+++ b/src/components/AppShell/AppShell.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Outlet } from 'react-router-dom';
+import { TopBar } from './TopBar';
+import { SideNav } from './SideNav';
+
+export const AppShell: React.FC = () => {
+  return (
+    <div className="app-shell">
+      <TopBar />
+      <div className="app-body">
+        <SideNav />
+        <main className="app-content">
+          <Outlet />
+        </main>
+      </div>
+    </div>
+  );
+};
+
+export default AppShell;

--- a/src/components/AppShell/SideNav.tsx
+++ b/src/components/AppShell/SideNav.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { NavLink } from 'react-router-dom';
+
+export const SideNav: React.FC = () => (
+  <nav className="side-nav">
+    <ul>
+      <li>
+        <NavLink to="/">Overview</NavLink>
+      </li>
+      <li>
+        <NavLink to="/model-lab">Model Lab</NavLink>
+      </li>
+    </ul>
+  </nav>
+);
+
+export default SideNav;

--- a/src/components/AppShell/TopBar.tsx
+++ b/src/components/AppShell/TopBar.tsx
@@ -1,0 +1,23 @@
+import React, { useEffect, useState } from 'react';
+
+export const TopBar: React.FC = () => {
+  const [theme, setTheme] = useState<'light' | 'dark'>('light');
+
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme((prev) => (prev === 'light' ? 'dark' : 'light'));
+  };
+
+  return (
+    <header className="top-bar">
+      <button onClick={toggleTheme} aria-label="Toggle theme">
+        {theme === 'light' ? '🌞' : '🌙'}
+      </button>
+    </header>
+  );
+};
+
+export default TopBar;

--- a/src/components/common/CompositeChart.tsx
+++ b/src/components/common/CompositeChart.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export const CompositeChart: React.FC = () => (
+  <div className="composite-chart">Composite Chart Placeholder</div>
+);
+
+export default CompositeChart;

--- a/src/components/common/DataQualityBanner.tsx
+++ b/src/components/common/DataQualityBanner.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+interface DataQualityBannerProps {
+  message: string;
+}
+
+export const DataQualityBanner: React.FC<DataQualityBannerProps> = ({
+  message,
+}) => <div className="data-quality-banner">{message}</div>;
+
+export default DataQualityBanner;

--- a/src/components/common/HyperparamSlider.tsx
+++ b/src/components/common/HyperparamSlider.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+interface HyperparamSliderProps {
+  label: string;
+  value: number;
+  min?: number;
+  max?: number;
+  step?: number;
+  onChange: (value: number) => void;
+}
+
+export const HyperparamSlider: React.FC<HyperparamSliderProps> = ({
+  label,
+  value,
+  min = 0,
+  max = 1,
+  step = 0.1,
+  onChange,
+}) => (
+  <label className="hyperparam-slider">
+    {label}
+    <input
+      type="range"
+      min={min}
+      max={max}
+      step={step}
+      value={value}
+      onChange={(e) => onChange(Number(e.target.value))}
+    />
+    <span>{value}</span>
+  </label>
+);
+
+export default HyperparamSlider;

--- a/src/components/common/KpiCard.tsx
+++ b/src/components/common/KpiCard.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+interface KpiCardProps {
+  label: string;
+  value: string | number;
+}
+
+export const KpiCard: React.FC<KpiCardProps> = ({ label, value }) => (
+  <div className="kpi-card">
+    <h3>{label}</h3>
+    <p>{value}</p>
+  </div>
+);
+
+export default KpiCard;

--- a/src/components/common/RunCard.tsx
+++ b/src/components/common/RunCard.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+interface RunCardProps {
+  title: string;
+  status: string;
+}
+
+export const RunCard: React.FC<RunCardProps> = ({ title, status }) => (
+  <div className="run-card">
+    <h4>{title}</h4>
+    <p>{status}</p>
+  </div>
+);
+
+export default RunCard;

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -1,0 +1,5 @@
+export * from './KpiCard';
+export * from './CompositeChart';
+export * from './RunCard';
+export * from './HyperparamSlider';
+export * from './DataQualityBanner';

--- a/src/components/system/AppSkeleton.tsx
+++ b/src/components/system/AppSkeleton.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export const AppSkeleton: React.FC = () => <div>Loading...</div>;
+
+export default AppSkeleton;

--- a/src/components/system/ErrorBoundary.tsx
+++ b/src/components/system/ErrorBoundary.tsx
@@ -1,0 +1,31 @@
+import React, { Component, ErrorInfo, ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error('ErrorBoundary caught an error', error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <div>Something went wrong.</div>;
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,8 +1,13 @@
-import React from 'react';
+import React, { Suspense } from 'react';
 import { createRoot } from 'react-dom/client';
 import { Provider } from 'react-redux';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { store } from './app/store';
-import App from './App';
+import AppShell from './components/AppShell/AppShell';
+import Overview from './pages/Overview';
+import ModelLab from './pages/ModelLab';
+import ErrorBoundary from './components/system/ErrorBoundary';
+import AppSkeleton from './components/system/AppSkeleton';
 import './index.css';
 
 const container = document.getElementById('root') as HTMLElement;
@@ -11,7 +16,23 @@ const root = createRoot(container);
 root.render(
   <React.StrictMode>
     <Provider store={store}>
-      <App />
+      <BrowserRouter>
+        <Routes>
+          <Route
+            path="/"
+            element={
+              <ErrorBoundary>
+                <Suspense fallback={<AppSkeleton />}>
+                  <AppShell />
+                </Suspense>
+              </ErrorBoundary>
+            }
+          >
+            <Route index element={<Overview />} />
+            <Route path="model-lab" element={<ModelLab />} />
+          </Route>
+        </Routes>
+      </BrowserRouter>
     </Provider>
   </React.StrictMode>,
 );

--- a/src/pages/ModelLab.tsx
+++ b/src/pages/ModelLab.tsx
@@ -1,0 +1,37 @@
+import React, { useState } from 'react';
+import {
+  DataQualityBanner,
+  HyperparamSlider,
+  RunCard,
+} from '../components/common';
+
+export const ModelLab: React.FC = () => {
+  const [learningRate, setLearningRate] = useState(0.01);
+  const [status, setStatus] = useState('Idle');
+
+  const startTraining = () => {
+    setStatus('Training started...');
+    setTimeout(() => {
+      setStatus('Training complete');
+    }, 1000);
+  };
+
+  return (
+    <div className="model-lab-page">
+      <DataQualityBanner message="Data looks good" />
+      <HyperparamSlider
+        label="Learning Rate"
+        value={learningRate}
+        min={0}
+        max={1}
+        step={0.01}
+        onChange={setLearningRate}
+      />
+      <button onClick={startTraining}>Train Model</button>
+      <div aria-live="polite">{status}</div>
+      <RunCard title="Latest Run" status={status} />
+    </div>
+  );
+};
+
+export default ModelLab;

--- a/src/pages/Overview.tsx
+++ b/src/pages/Overview.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { CompositeChart, KpiCard } from '../components/common';
+
+export const Overview: React.FC = () => (
+  <div className="overview-page">
+    <section className="kpi-section">
+      <KpiCard label="Accuracy" value="95%" />
+      <KpiCard label="Loss" value="0.05" />
+    </section>
+    <CompositeChart />
+  </div>
+);
+
+export default Overview;


### PR DESCRIPTION
## Summary
- add AppShell with top bar, side nav and theme toggle
- introduce common components and pages for Overview and Model Lab
- wire up React Router with error boundaries and loading skeleton

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a67da9c2bc832a8ac04a9bc413eecf