### PR TITLE
Manage chart size via Redux slice

### DIFF
--- a/src/app/store.js
+++ b/src/app/store.js
@@ -1,12 +1,14 @@
 import { configureStore } from '@reduxjs/toolkit';
 import counterReducer from '../features/counter/counterSlice';
 import brainReducer from '../features/brain/brainSlice';
+import chartSettingsReducer from '../features/chartSettings/chartSettingsSlice';
 import { marketApi } from '../features/markets/marketApi';
 
 export const store = configureStore({
   reducer: {
     counter: counterReducer,
     brain: brainReducer,
+    chartSettings: chartSettingsReducer,
     [marketApi.reducerPath]: marketApi.reducer,
   },
   middleware: (getDefaultMiddleware) =>

--- a/src/components/chart001.js
+++ b/src/components/chart001.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import {
   Chart as ChartJS,
   CategoryScale,
@@ -11,9 +11,12 @@ import {
   Legend,
 } from 'chart.js';
 import { Line } from 'react-chartjs-2';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import { useGetOhlcQuery } from '../features/markets/marketApi';
-import { chartSize } from '../features/chartSettings';
+import {
+  selectChartSize,
+  setChartSize,
+} from '../features/chartSettings/chartSettingsSlice';
 import { chartOptions } from '../charts/config';
 import { lineDataset } from '../charts/datasets';
 import { selectPredictionSeries } from '../selectors/seriesSelectors';
@@ -30,12 +33,9 @@ ChartJS.register(
 );
 
 export function ChartI() {
+  const dispatch = useDispatch();
   const { labels, values } = useSelector(selectPredictionSeries);
-  const [tickAmount, setTickAmount] = useState(5);
-  chartSize.push(tickAmount);
-  if (chartSize.length >= 2) {
-    chartSize.splice(0, 1);
-  }
+  const tickAmount = useSelector(selectChartSize);
 
   const { refetch } = useGetOhlcQuery({ symbol: 'BTCUSDT', interval: '1m' });
   const fetchData = () => {
@@ -96,7 +96,7 @@ export function ChartI() {
 
       <div style={{ display: 'flexbox', flexDirection: 'row' }}>
         <button
-          onClick={() => setTickAmount(5)}
+          onClick={() => dispatch(setChartSize(5))}
           style={{
             borderRadius: '9px',
             marginTop: '25px',
@@ -107,7 +107,7 @@ export function ChartI() {
           5
         </button>
         <button
-          onClick={() => setTickAmount(10)}
+          onClick={() => dispatch(setChartSize(10))}
           style={{
             borderRadius: '9px',
             marginTop: '25px',
@@ -118,7 +118,7 @@ export function ChartI() {
           10
         </button>
         <button
-          onClick={() => setTickAmount(15)}
+          onClick={() => dispatch(setChartSize(15))}
           style={{
             borderRadius: '9px',
             marginTop: '25px',
@@ -129,7 +129,7 @@ export function ChartI() {
           15
         </button>
         <button
-          onClick={() => setTickAmount(20)}
+          onClick={() => dispatch(setChartSize(20))}
           style={{
             borderRadius: '9px',
             marginTop: '25px',
@@ -140,7 +140,7 @@ export function ChartI() {
           20
         </button>
         <button
-          onClick={() => setTickAmount(30)}
+          onClick={() => dispatch(setChartSize(30))}
           style={{
             borderRadius: '9px',
             marginTop: '25px',
@@ -153,7 +153,7 @@ export function ChartI() {
       </div>
 
       <button
-        onClick={() => setTickAmount(500)}
+        onClick={() => dispatch(setChartSize(500))}
         style={{
           borderRadius: '9px',
           marginTop: '25px',

--- a/src/components/chart002.js
+++ b/src/components/chart002.js
@@ -16,6 +16,7 @@ import { useGetOhlcQuery } from '../features/markets/marketApi';
 import { chartOptions } from '../charts/config';
 import { lineDataset } from '../charts/datasets';
 import { selectMetricSeries } from '../selectors/seriesSelectors';
+import { selectChartSize } from '../features/chartSettings/chartSettingsSlice';
 
 ChartJS.register(
   CategoryScale,
@@ -33,6 +34,7 @@ ChartJS.register(
 
 export function ChartII() {
   const { labels, values } = useSelector(selectMetricSeries);
+  const tickAmount = useSelector(selectChartSize);
   useGetOhlcQuery({ symbol: 'BTCUSDT', interval: '1m' });
 
   const data = {
@@ -44,6 +46,7 @@ export function ChartII() {
     <div style={{ display: 'flexbox', width: '900px' }}>
       <Line data={data} options={chartOptions} />
       <br />
+      <p>{tickAmount}</p>
     </div>
   );
 }

--- a/src/components/chart003.js
+++ b/src/components/chart003.js
@@ -18,6 +18,7 @@ import { useGetOhlcQuery } from '../features/markets/marketApi';
 import { chartOptions } from '../charts/config';
 import { barDataset } from '../charts/datasets';
 import { selectMetricSeries } from '../selectors/seriesSelectors';
+import { selectChartSize } from '../features/chartSettings/chartSettingsSlice';
 
 ChartJS.register(
   CategoryScale,
@@ -36,6 +37,7 @@ ChartJS.register(
 
 export function ChartIII() {
   const { labels, values } = useSelector(selectMetricSeries);
+  const tickAmount = useSelector(selectChartSize);
   useGetOhlcQuery({ symbol: 'BTCUSDT', interval: '1m' });
 
   const data = {
@@ -47,6 +49,7 @@ export function ChartIII() {
     <div style={{ display: 'flexbox', width: '900px' }}>
       <Bar data={data} options={chartOptions} />
       <br />
+      <p>{tickAmount}</p>
     </div>
   );
 }

--- a/src/features/chartSettings.js
+++ b/src/features/chartSettings.js
@@ -1,3 +1,0 @@
-export let chartSize = [];
-
-// Additional UI-only data settings can be placed here in the future.

--- a/src/features/chartSettings/chartSettingsSlice.js
+++ b/src/features/chartSettings/chartSettingsSlice.js
@@ -1,0 +1,19 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const initialState = {
+  size: 5,
+};
+
+const chartSettingsSlice = createSlice({
+  name: 'chartSettings',
+  initialState,
+  reducers: {
+    setChartSize: (state, action) => {
+      state.size = action.payload;
+    },
+  },
+});
+
+export const { setChartSize } = chartSettingsSlice.actions;
+export const selectChartSize = (state) => state.chartSettings.size;
+export default chartSettingsSlice.reducer;

--- a/src/features/normalizerFactories/btc-usdt.js
+++ b/src/features/normalizerFactories/btc-usdt.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { chartSize } from '../chartSettings';
+import { selectChartSize } from '../chartSettings/chartSettingsSlice';
 const brain = require('brain.js');
 
 const createConfig = (activation = 'tanh', overrides = {}) => ({
@@ -84,23 +84,18 @@ let brMesurementSliceColor001 = [];
   let start = 1;
   let end = 0;
 
-export const getData = ({
-    time,
-    tickAmount
-}) => async dispatch => {
+export const getData = ({ time }) => async (dispatch, getState) => {
     try{
         dispatch({
             type: "AWAITING_BITCOIN"
         })
-
-        console.log(tickAmount)
 //////////////////////////////////////////////////
 //////////////////////////////////////////////////
 
         start++; //start = 1
-        
+
         end++;
-        var grab = chartSize[0].valueOf();
+        const grab = selectChartSize(getState());
         if(end >= grab) {start = end - grab} else {start = 0};
         console.log('CHART SIZE(GRAB):', grab, 'START VALUE: ', start, 'END VALUE: ', end);
 


### PR DESCRIPTION
## Summary
- add chartSettings slice to track chart size in Redux
- update chart components to read and dispatch chart size changes
- connect normalizer factory and store to the new slice

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a68afd7864832aa1a701f6c46f9220