### PR TITLE
feat: add configurable Binance base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,12 @@ Vite exposes only variables prefixed with `VITE_` to client code. Define them in
 
 ```
 VITE_API_URL=https://api.example.com
+VITE_BINANCE_BASE_URL=https://api.binance.com/api/v3/
 ```
 
-Access them via `import.meta.env.VITE_API_URL`.
+Access them via `import.meta.env.VITE_API_URL`. `marketApi` reads
+`VITE_BINANCE_BASE_URL` to configure the Binance API base URL, falling back to
+Binance's public endpoint if the variable is missing.
 
 ## Screenshots
 

--- a/src/features/markets/marketApi.ts
+++ b/src/features/markets/marketApi.ts
@@ -1,8 +1,18 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 
+const binanceBaseUrl =
+  import.meta.env.VITE_BINANCE_BASE_URL ?? 'https://api.binance.com/api/v3/';
+
+if (!import.meta.env.VITE_BINANCE_BASE_URL) {
+  // eslint-disable-next-line no-console
+  console.warn(
+    'VITE_BINANCE_BASE_URL is not defined; falling back to https://api.binance.com/api/v3/'
+  );
+}
+
 export const marketApi = createApi({
   reducerPath: 'marketApi',
-  baseQuery: fetchBaseQuery({ baseUrl: 'https://api.binance.com/api/v3/' }),
+  baseQuery: fetchBaseQuery({ baseUrl: binanceBaseUrl }),
   endpoints: (builder) => ({
     getOhlc: builder.query<any, { symbol?: string; interval?: string }>({
       query: ({ symbol = 'BTCUSDT', interval = '1m' } = {}) =>


### PR DESCRIPTION
## Summary
- make Binance API endpoint configurable via `VITE_BINANCE_BASE_URL`
- fall back to the public Binance API if the variable is missing
- document `VITE_BINANCE_BASE_URL` in README

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a68c66bfd0832aad0d7f42ea7a4b48