### PR TITLE
test: mock DOM APIs for Vitest

### DIFF
--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,1 +1,62 @@
 import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+
+// Mock window.matchMedia
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(), // deprecated
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+// Mock ResizeObserver
+class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+Object.defineProperty(window, 'ResizeObserver', {
+  writable: true,
+  value: ResizeObserver,
+});
+
+// Mock IntersectionObserver
+class IntersectionObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+  takeRecords() {
+    return [];
+  }
+}
+Object.defineProperty(window, 'IntersectionObserver', {
+  writable: true,
+  value: IntersectionObserver,
+});
+
+// Mock canvas getContext for Chart.js
+HTMLCanvasElement.prototype.getContext = vi.fn(() => ({
+  canvas: document.createElement('canvas'),
+  fillRect: vi.fn(),
+  clearRect: vi.fn(),
+  getImageData: vi.fn(),
+  putImageData: vi.fn(),
+  createImageData: vi.fn(),
+  setTransform: vi.fn(),
+  drawImage: vi.fn(),
+  save: vi.fn(),
+  fillText: vi.fn(),
+  restore: vi.fn(),
+  beginPath: vi.fn(),
+  moveTo: vi.fn(),
+  lineTo: vi.fn(),
+  closePath: vi.fn(),
+  stroke: vi.fn(),
+}));


### PR DESCRIPTION
## Summary
- ensure vitest uses jsdom with setup file
- mock matchMedia, ResizeObserver, IntersectionObserver, and canvas context for tests

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a80e46a484832a80bfb22f1fe10bbf