### PR TITLE
test: centralize react-chartjs-2 mock setup

### DIFF
--- a/src/components/chartIntegration.test.tsx
+++ b/src/components/chartIntegration.test.tsx
@@ -2,16 +2,12 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { Provider, useSelector } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
-import { vi, describe, it, expect } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import brainReducer from '../features/brain/brainSlice';
 import chartSettingsReducer from '../features/chartSettings/chartSettingsSlice';
 import { lineDataset } from '../charts/datasets';
 import { selectMetricSeries } from '../selectors/seriesSelectors';
 import { Line } from 'react-chartjs-2';
-
-vi.mock('react-chartjs-2', () => ({
-  Line: ({ data }: { data: unknown }) => <div data-testid="chart-output">{JSON.stringify(data)}</div>,
-}));
 
 const TestChart: React.FC = () => {
   const { labels, values } = useSelector(selectMetricSeries);

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,4 +1,5 @@
 import '@testing-library/jest-dom';
+import React from 'react';
 import { vi } from 'vitest';
 
 // Mock window.matchMedia
@@ -60,3 +61,24 @@ HTMLCanvasElement.prototype.getContext = vi.fn(() => ({
   closePath: vi.fn(),
   stroke: vi.fn(),
 }));
+
+// Stub out react-chartjs-2 components with simple div placeholders
+vi.mock('react-chartjs-2', () => {
+  const ChartStub = ({ data }: { data?: unknown }) =>
+    React.createElement(
+      'div',
+      { 'data-testid': 'chart-output' },
+      data ? JSON.stringify(data) : null
+    );
+
+  return {
+    Line: ChartStub,
+    Bar: ChartStub,
+    Pie: ChartStub,
+    Doughnut: ChartStub,
+    Radar: ChartStub,
+    PolarArea: ChartStub,
+    Bubble: ChartStub,
+    Scatter: ChartStub,
+  } as Record<string, unknown>;
+});


### PR DESCRIPTION
## Summary
- mock react-chartjs-2 globally in vitest setup with div stubs
- drop per-test mock in chartIntegration test

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68a81b142434832a9deb30b85baa773a