### PR TITLE
test: wrap page specs with memory router

### DIFF
--- a/src/pages/ModelLab.spec.tsx
+++ b/src/pages/ModelLab.spec.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
+import { MemoryRouter } from 'react-router-dom';
 import brainReducer from '../features/brain/brainSlice';
 import ModelLab from './ModelLab';
 
@@ -10,9 +11,11 @@ describe('ModelLab page', () => {
   it('renders training controls', () => {
     const store = configureStore({ reducer: { brain: brainReducer } });
     render(
-      <Provider store={store}>
-        <ModelLab />
-      </Provider>
+      <MemoryRouter>
+        <Provider store={store}>
+          <ModelLab />
+        </Provider>
+      </MemoryRouter>
     );
     expect(screen.getByText('Train Model')).toBeInTheDocument();
     expect(screen.getByText(/Latest Run/i)).toBeInTheDocument();

--- a/src/pages/Overview.spec.tsx
+++ b/src/pages/Overview.spec.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
+import { MemoryRouter } from 'react-router-dom';
 import brainReducer from '../features/brain/brainSlice';
 import Overview from './Overview';
 
@@ -10,9 +11,11 @@ describe('Overview page', () => {
   it('renders CompositeChart', () => {
     const store = configureStore({ reducer: { brain: brainReducer } });
     render(
-      <Provider store={store}>
-        <Overview />
-      </Provider>
+      <MemoryRouter>
+        <Provider store={store}>
+          <Overview />
+        </Provider>
+      </MemoryRouter>
     );
     expect(screen.getByText(/Composite Chart Placeholder/i)).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary
- import `MemoryRouter` into ModelLab and Overview specs
- wrap Redux provider with memory router in page tests

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68a81bf39d88832a8b370c8db3f7012a