### PR TITLE
Show percentage error in tooltip

### DIFF
--- a/src/features/charts/ChartCanvas.tsx
+++ b/src/features/charts/ChartCanvas.tsx
@@ -200,7 +200,10 @@ export const ChartCanvas: React.FC = () => {
         html += `<div><span style="color:${color}">${
           brains.byId[id]?.config.name ?? id
         }: ${Number(price).toFixed(2)}</span>`;
-        if (err !== undefined) html += ` <span>err ${err.toFixed(2)}</span>`;
+        if (err !== undefined) {
+          const pctErr = (err / Number(actual)) * 100;
+          html += ` <span>err ${err.toFixed(2)} (${pctErr.toFixed(2)}%)</span>`;
+        }
         if (metrics) {
           const parts: string[] = [];
           if (metrics.mse !== undefined) parts.push(`mse ${metrics.mse.toFixed(4)}`);


### PR DESCRIPTION
## Summary
- compute percentage error relative to actual series
- show absolute and percentage error in prediction tooltips

## Testing
- `pnpm test`
- `pnpm lint` *(fails: Unexpected any, no-unused-vars, @ts-ignore in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2f5d0844832aa2b5b896d4853bf7