### PR TITLE
feat: add training workflow and chart

### DIFF
--- a/src/components/common/CompositeChart.tsx
+++ b/src/components/common/CompositeChart.tsx
@@ -1,7 +1,71 @@
 import React from 'react';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend,
+} from 'chart.js';
+import { Line } from 'react-chartjs-2';
 
-export const CompositeChart: React.FC = () => (
-  <div className="composite-chart">Composite Chart Placeholder</div>
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  Title,
+  Tooltip,
+  Legend,
 );
+
+interface CompositeChartProps {
+  labels: (string | number)[];
+  actualData: number[];
+  predictedData: number[];
+}
+
+export const CompositeChart: React.FC<CompositeChartProps> = ({
+  labels,
+  actualData,
+  predictedData,
+}) => {
+  const data = {
+    labels,
+    datasets: [
+      {
+        label: 'Actual',
+        data: actualData,
+        borderColor: 'rgb(54, 162, 235)',
+        backgroundColor: 'rgba(54, 162, 235, 0.3)',
+        fill: false,
+      },
+      {
+        label: 'Predicted',
+        data: predictedData,
+        borderColor: 'rgb(255, 99, 132)',
+        backgroundColor: 'rgba(255, 99, 132, 0.3)',
+        fill: false,
+      },
+    ],
+  };
+
+  const options = {
+    responsive: true,
+    plugins: {
+      legend: {
+        position: 'top' as const,
+      },
+      title: {
+        display: false,
+        text: 'Predictions vs Actual',
+      },
+    },
+  };
+
+  return <Line data={data} options={options} />;
+};
 
 export default CompositeChart;

--- a/src/components/common/KpiCard.tsx
+++ b/src/components/common/KpiCard.tsx
@@ -6,9 +6,12 @@ interface KpiCardProps {
 }
 
 export const KpiCard: React.FC<KpiCardProps> = ({ label, value }) => (
-  <div className="kpi-card">
-    <h3>{label}</h3>
-    <p>{value}</p>
+  <div
+    className="kpi-card"
+    style={{ border: '1px solid #ccc', padding: '8px', borderRadius: '4px' }}
+  >
+    <h3 style={{ margin: 0, fontSize: '1rem' }}>{label}</h3>
+    <p style={{ margin: 0, fontSize: '1.2rem', fontWeight: 'bold' }}>{value}</p>
   </div>
 );
 

--- a/src/components/common/RunCard.tsx
+++ b/src/components/common/RunCard.tsx
@@ -2,13 +2,27 @@ import React from 'react';
 
 interface RunCardProps {
   title: string;
-  status: string;
+  status: 'idle' | 'running' | 'complete' | 'error';
 }
 
+const statusColor: Record<RunCardProps['status'], string> = {
+  idle: '#ccc',
+  running: 'orange',
+  complete: 'green',
+  error: 'red',
+};
+
 export const RunCard: React.FC<RunCardProps> = ({ title, status }) => (
-  <div className="run-card">
-    <h4>{title}</h4>
-    <p>{status}</p>
+  <div
+    className="run-card"
+    style={{
+      border: `2px solid ${statusColor[status]}`,
+      padding: '8px',
+      borderRadius: '4px',
+    }}
+  >
+    <h4 style={{ margin: 0 }}>{title}</h4>
+    <p style={{ margin: 0 }}>{status}</p>
   </div>
 );
 

--- a/src/features/training/trainingSlice.ts
+++ b/src/features/training/trainingSlice.ts
@@ -1,0 +1,79 @@
+import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
+import type { RootState } from '@/store';
+import type { BrainConfig, PredictionPoint, TrainingMetrics } from '@/types/brain';
+import { trainBrain } from '@/lib/brain/train';
+
+export interface TrainingState {
+  predictions: PredictionPoint[];
+  metrics: TrainingMetrics | null;
+  status: 'idle' | 'running' | 'complete' | 'error';
+  error?: string;
+  progress?: { iter: number; error: number; elapsedMs: number };
+}
+
+const initialState: TrainingState = {
+  predictions: [],
+  metrics: null,
+  status: 'idle',
+};
+
+export interface TrainModelArgs {
+  config: BrainConfig;
+  dataset: { timestamps: number[]; open: number[] };
+}
+
+export const trainModelAsync = createAsyncThunk(
+  'training/trainModel',
+  async (
+    { config, dataset }: TrainModelArgs,
+    { dispatch },
+  ) => {
+    const result = await trainBrain(config, dataset, {
+      logProgress: true,
+      onProgress(iter, error, elapsedMs) {
+        dispatch(progressUpdated({ iter, error, elapsedMs }));
+      },
+    });
+    return result;
+  },
+);
+
+export const trainingSlice = createSlice({
+  name: 'training',
+  initialState,
+  reducers: {
+    progressUpdated(
+      state,
+      action: PayloadAction<{ iter: number; error: number; elapsedMs: number }>,
+    ) {
+      state.progress = action.payload;
+    },
+  },
+  extraReducers: (builder) => {
+    builder
+      .addCase(trainModelAsync.pending, (state) => {
+        state.status = 'running';
+        state.error = undefined;
+        state.progress = undefined;
+      })
+      .addCase(trainModelAsync.fulfilled, (state, action) => {
+        state.status = 'complete';
+        state.predictions = action.payload.predictions;
+        state.metrics = action.payload.metrics;
+      })
+      .addCase(trainModelAsync.rejected, (state, action) => {
+        state.status = 'error';
+        state.error = action.error.message;
+      });
+  },
+});
+
+export const { progressUpdated } = trainingSlice.actions;
+
+export const selectPredictions = (state: RootState) =>
+  state.training.predictions;
+export const selectMetrics = (state: RootState) => state.training.metrics;
+export const selectTrainingStatus = (state: RootState) => state.training.status;
+export const selectProgress = (state: RootState) => state.training.progress;
+
+export default trainingSlice.reducer;

--- a/src/pages/ModelLab.spec.tsx
+++ b/src/pages/ModelLab.spec.tsx
@@ -4,12 +4,34 @@ import { render, screen } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
 import { MemoryRouter } from 'react-router-dom';
-import brainReducer from '../features/brain/brainSlice';
+import trainingReducer from '@/features/training/trainingSlice';
+import datasetsReducer from '@/features/datasets/datasetsSlice';
 import ModelLab from './ModelLab';
 
 describe('ModelLab page', () => {
   it('renders training controls', () => {
-    const store = configureStore({ reducer: { brain: brainReducer } });
+    const store = configureStore({
+      reducer: { training: trainingReducer, datasets: datasetsReducer },
+      preloadedState: {
+        datasets: {
+          byId: {
+            open: {
+              id: 'open',
+              timestamps: [1, 2, 3],
+              open: [1, 2, 3],
+              normalized: [0, 0.5, 1],
+              series: [
+                { t: 1, y: 1 },
+                { t: 2, y: 2 },
+                { t: 3, y: 3 },
+              ],
+            },
+          },
+          allIds: ['open'],
+          activeDatasetId: 'open',
+        },
+      },
+    });
     render(
       <MemoryRouter>
         <Provider store={store}>

--- a/src/pages/ModelLab.tsx
+++ b/src/pages/ModelLab.tsx
@@ -4,21 +4,53 @@ import {
   HyperparamSlider,
   RunCard,
 } from '../components/common';
+import { useAppDispatch, useAppSelector } from '@/store/hooks';
+import {
+  selectTrainingStatus,
+  selectProgress,
+  trainModelAsync,
+} from '@/features/training/trainingSlice';
+import {
+  selectOpenSeries,
+  selectTimestamps,
+} from '@/features/datasets/datasetsSlice';
+import type { BrainConfig } from '@/types/brain';
 
 export const ModelLab: React.FC = () => {
+  const dispatch = useAppDispatch();
+  const status = useAppSelector(selectTrainingStatus);
+  const progress = useAppSelector(selectProgress);
+  const open = useAppSelector(selectOpenSeries);
+  const timestamps = useAppSelector(selectTimestamps);
+
   const [learningRate, setLearningRate] = useState(0.01);
-  const [status, setStatus] = useState('Idle');
+  const [iterations, setIterations] = useState(1000);
 
   const startTraining = () => {
-    setStatus('Training started...');
-    setTimeout(() => {
-      setStatus('Training complete');
-    }, 1000);
+    const config: BrainConfig = {
+      id: 'temp',
+      name: 'TempBrain',
+      architecture: { type: 'feedforward', hiddenLayers: [8, 8], activation: 'sigmoid' },
+      hyper: {
+        learningRate,
+        iterations,
+        errorThresh: 0.005,
+      },
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+
+    dispatch(
+      trainModelAsync({
+        config,
+        dataset: { timestamps, open },
+      }),
+    );
   };
 
   return (
     <div className="model-lab-page">
-      <DataQualityBanner message="Data looks good" />
+      <DataQualityBanner message={open.length ? 'Data loaded' : 'No data'} />
       <HyperparamSlider
         label="Learning Rate"
         value={learningRate}
@@ -27,8 +59,20 @@ export const ModelLab: React.FC = () => {
         step={0.01}
         onChange={setLearningRate}
       />
+      <HyperparamSlider
+        label="Iterations"
+        value={iterations}
+        min={100}
+        max={5000}
+        step={100}
+        onChange={setIterations}
+      />
       <button onClick={startTraining}>Train Model</button>
-      <div aria-live="polite">{status}</div>
+      {status === 'running' && progress ? (
+        <div aria-live="polite">
+          Iter {progress.iter} Error {progress.error.toFixed(4)}
+        </div>
+      ) : null}
       <RunCard title="Latest Run" status={status} />
     </div>
   );

--- a/src/pages/Overview.spec.tsx
+++ b/src/pages/Overview.spec.tsx
@@ -4,12 +4,34 @@ import { render, screen } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
 import { MemoryRouter } from 'react-router-dom';
-import brainReducer from '../features/brain/brainSlice';
+import trainingReducer from '@/features/training/trainingSlice';
+import datasetsReducer from '@/features/datasets/datasetsSlice';
 import Overview from './Overview';
 
 describe('Overview page', () => {
   it('renders CompositeChart', () => {
-    const store = configureStore({ reducer: { brain: brainReducer } });
+    const store = configureStore({
+      reducer: { training: trainingReducer, datasets: datasetsReducer },
+      preloadedState: {
+        datasets: {
+          byId: {
+            open: {
+              id: 'open',
+              timestamps: [1, 2, 3],
+              open: [1, 2, 3],
+              normalized: [0, 0.5, 1],
+              series: [
+                { t: 1, y: 1 },
+                { t: 2, y: 2 },
+                { t: 3, y: 3 },
+              ],
+            },
+          },
+          allIds: ['open'],
+          activeDatasetId: 'open',
+        },
+      },
+    });
     render(
       <MemoryRouter>
         <Provider store={store}>
@@ -17,6 +39,6 @@ describe('Overview page', () => {
         </Provider>
       </MemoryRouter>
     );
-    expect(screen.getByText(/Composite Chart Placeholder/i)).toBeInTheDocument();
+    expect(screen.getByText(/No training results yet/i)).toBeInTheDocument();
   });
 });

--- a/src/pages/Overview.tsx
+++ b/src/pages/Overview.tsx
@@ -1,14 +1,60 @@
 import React from 'react';
-import { CompositeChart, KpiCard } from '../components/common';
+import {
+  CompositeChart,
+  KpiCard,
+  DataQualityBanner,
+} from '../components/common';
+import { useAppSelector } from '@/store/hooks';
+import { selectPredictions, selectMetrics } from '@/features/training/trainingSlice';
+import {
+  selectOpenSeries,
+  selectTimestamps,
+} from '@/features/datasets/datasetsSlice';
 
-export const Overview: React.FC = () => (
-  <div className="overview-page">
-    <section className="kpi-section">
-      <KpiCard label="Accuracy" value="95%" />
-      <KpiCard label="Loss" value="0.05" />
-    </section>
-    <CompositeChart />
-  </div>
-);
+export const Overview: React.FC = () => {
+  const predictions = useAppSelector(selectPredictions);
+  const metrics = useAppSelector(selectMetrics);
+  const open = useAppSelector(selectOpenSeries);
+  const timestamps = useAppSelector(selectTimestamps);
+
+  const labels = predictions.map((p) => new Date(p.t).toLocaleString());
+  const predicted = predictions.map((p) => p.y);
+  const actual = predictions.map((p) => {
+    const idx = timestamps.indexOf(p.t);
+    return idx !== -1 ? open[idx] : 0;
+  });
+
+  const hasResults = predictions.length > 0;
+
+  return (
+    <div className="overview-page">
+      {hasResults ? (
+        <>
+          <section className="kpi-section">
+            <KpiCard
+              label="MSE"
+              value={metrics?.mse?.toFixed(4) ?? '-'}
+            />
+            <KpiCard
+              label="MAE"
+              value={metrics?.mae?.toFixed(4) ?? '-'}
+            />
+            <KpiCard
+              label="MAPE"
+              value={metrics?.mape?.toFixed(2) ?? '-'}
+            />
+          </section>
+          <CompositeChart
+            labels={labels}
+            actualData={actual}
+            predictedData={predicted}
+          />
+        </>
+      ) : (
+        <DataQualityBanner message="No training results yet" />
+      )}
+    </div>
+  );
+};
 
 export default Overview;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -5,6 +5,7 @@ import { configureStore, type PreloadedState } from '@reduxjs/toolkit';
 import brainsReducer, { type BrainsState } from '@/store/brainsSlice';
 import datasetsReducer, { type DatasetsState } from '@/features/datasets/datasetsSlice';
 import chartsReducer, { type ChartsState } from '@/features/charts/chartsSlice';
+import trainingReducer, { type TrainingState } from '@/features/training/trainingSlice';
 import { loadSession, saveSession } from '@/lib/persist/session';
 
 const preloaded = loadSession();
@@ -14,11 +15,13 @@ export const store = configureStore({
     brains: brainsReducer,
     datasets: datasetsReducer,
     charts: chartsReducer,
+    training: trainingReducer,
   },
   preloadedState: preloaded as PreloadedState<{
     brains: BrainsState;
     datasets: DatasetsState;
     charts: ChartsState;
+    training: TrainingState;
   }>,
 });
 

--- a/src/types/brain.ts
+++ b/src/types/brain.ts
@@ -74,3 +74,13 @@ export interface BrainPredictionSeries {
   brainId: BrainId;
   points: SeriesPoint[];
 }
+
+// Prediction output from training
+export type PredictionPoint = SeriesPoint;
+
+// Metrics returned by training
+export interface TrainingMetrics {
+  mse: number;
+  mae: number;
+  mape: number;
+}


### PR DESCRIPTION
## Summary
- add training slice with async thunk for brain.js training
- wire ModelLab to dispatch training and show progress
- render predictions and metrics in Overview with composite Chart.js line chart

## Testing
- `pnpm test` *(fails: vitest not found)*
- `pnpm install` *(fails: Forbidden 403)*

------
https://chatgpt.com/codex/tasks/task_e_68aff252df10832a9a9c53e809eb5a0c