### PR TITLE
feat(ui): styled KPI & banner components + accessible hyperparam slider and run card

### DIFF
--- a/src/components/common/DataQualityBanner.module.css
+++ b/src/components/common/DataQualityBanner.module.css
@@ -1,0 +1,38 @@
+.banner {
+  display: flex;
+  align-items: center;
+  padding: 8px 12px;
+  border-radius: 4px;
+  margin: 8px 0;
+  font-size: 0.875rem;
+}
+.icon {
+  margin-right: 8px;
+}
+.message {
+  flex: 1;
+}
+.close {
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1rem;
+  line-height: 1;
+  margin-left: 8px;
+}
+.info {
+  background-color: #e0f2fe;
+  color: #0369a1;
+}
+.warning {
+  background-color: #fef9c3;
+  color: #92400e;
+}
+.error {
+  background-color: #fee2e2;
+  color: #b91c1c;
+}
+.success {
+  background-color: #dcfce7;
+  color: #166534;
+}

--- a/src/components/common/DataQualityBanner.tsx
+++ b/src/components/common/DataQualityBanner.tsx
@@ -1,11 +1,58 @@
-import React from 'react';
+import React, { useState } from 'react';
+import styles from './DataQualityBanner.module.css';
 
-interface DataQualityBannerProps {
+export type BannerVariant = 'info' | 'warning' | 'error' | 'success';
+
+export interface DataQualityBannerProps {
+  variant?: BannerVariant;
   message: string;
+  dismissible?: boolean;
+  onClose?: () => void;
+  className?: string;
 }
 
+const variantIcons: Record<BannerVariant, string> = {
+  info: 'ℹ️',
+  warning: '⚠️',
+  error: '❌',
+  success: '✅',
+};
+
 export const DataQualityBanner: React.FC<DataQualityBannerProps> = ({
+  variant = 'info',
   message,
-}) => <div className="data-quality-banner">{message}</div>;
+  dismissible = false,
+  onClose,
+  className,
+}) => {
+  const [visible, setVisible] = useState(true);
+  if (!visible) return null;
+  const role = variant === 'error' ? 'alert' : 'status';
+  const classes = [styles.banner, styles[variant], className]
+    .filter(Boolean)
+    .join(' ');
+
+  const handleClose = () => {
+    setVisible(false);
+    onClose?.();
+  };
+
+  return (
+    <div className={classes} role={role} aria-live={variant === 'error' ? 'assertive' : 'polite'}>
+      <span className={styles.icon}>{variantIcons[variant]}</span>
+      <span className={styles.message}>{message}</span>
+      {dismissible && (
+        <button
+          type="button"
+          className={styles.close}
+          onClick={handleClose}
+          aria-label="Close banner"
+        >
+          ×
+        </button>
+      )}
+    </div>
+  );
+};
 
 export default DataQualityBanner;

--- a/src/components/common/HyperparamSlider.module.css
+++ b/src/components/common/HyperparamSlider.module.css
@@ -1,0 +1,19 @@
+.container {
+  margin: 8px 0;
+}
+.labelLine {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.875rem;
+  margin-bottom: 4px;
+}
+.valueDisplay {
+  font-weight: 500;
+}
+.slider {
+  width: 100%;
+}
+.slider:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/src/components/common/HyperparamSlider.tsx
+++ b/src/components/common/HyperparamSlider.tsx
@@ -1,12 +1,17 @@
-import React from 'react';
+import React, { useId } from 'react';
+import styles from './HyperparamSlider.module.css';
 
-interface HyperparamSliderProps {
+export interface HyperparamSliderProps {
   label: string;
   value: number;
   min?: number;
   max?: number;
   step?: number;
   onChange: (value: number) => void;
+  suffix?: string;
+  precision?: number;
+  disabled?: boolean;
+  className?: string;
 }
 
 export const HyperparamSlider: React.FC<HyperparamSliderProps> = ({
@@ -16,19 +21,39 @@ export const HyperparamSlider: React.FC<HyperparamSliderProps> = ({
   max = 1,
   step = 0.1,
   onChange,
-}) => (
-  <label className="hyperparam-slider">
-    {label}
-    <input
-      type="range"
-      min={min}
-      max={max}
-      step={step}
-      value={value}
-      onChange={(e) => onChange(Number(e.target.value))}
-    />
-    <span>{value}</span>
-  </label>
-);
+  suffix = '',
+  precision = 2,
+  disabled = false,
+  className,
+}) => {
+  const sliderId = useId();
+  const valueId = useId();
+  const formatted = value.toFixed(precision) + suffix;
+  const classes = [styles.container, className].filter(Boolean).join(' ');
+
+  return (
+    <div className={classes}>
+      <label htmlFor={sliderId} className={styles.labelLine}>
+        <span>{label}:</span>
+        <span id={valueId} className={styles.valueDisplay}>
+          {formatted}
+        </span>
+      </label>
+      <input
+        id={sliderId}
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+        aria-label={label}
+        aria-describedby={valueId}
+        disabled={disabled}
+        className={styles.slider}
+      />
+    </div>
+  );
+};
 
 export default HyperparamSlider;

--- a/src/components/common/KpiCard.module.css
+++ b/src/components/common/KpiCard.module.css
@@ -1,0 +1,51 @@
+.card {
+  padding: 12px;
+  background: #ffffff;
+  border-radius: 8px;
+  border-top: 4px solid var(--accent, #e5e7eb);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  transition: box-shadow 0.2s ease-in-out;
+  outline: none;
+}
+.card:hover,
+.card:focus {
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+}
+.card:focus {
+  outline: 2px solid #3b82f6;
+  outline-offset: 2px;
+}
+.label {
+  color: #6b7280;
+  font-size: 0.875rem;
+}
+.value {
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: var(--value-color, #111827);
+}
+.helpText {
+  font-size: 0.75rem;
+  color: #6b7280;
+  margin-top: 4px;
+}
+.accent-default {
+  --accent: #e5e7eb;
+  --value-color: #111827;
+}
+.accent-blue {
+  --accent: #3b82f6;
+  --value-color: #3b82f6;
+}
+.accent-green {
+  --accent: #10b981;
+  --value-color: #10b981;
+}
+.accent-red {
+  --accent: #ef4444;
+  --value-color: #ef4444;
+}
+.accent-amber {
+  --accent: #f59e0b;
+  --value-color: #f59e0b;
+}

--- a/src/components/common/KpiCard.tsx
+++ b/src/components/common/KpiCard.tsx
@@ -1,18 +1,36 @@
 import React from 'react';
+import styles from './KpiCard.module.css';
 
-interface KpiCardProps {
+export interface KpiCardProps {
   label: string;
   value: string | number;
+  helpText?: string;
+  colorScheme?: 'default' | 'blue' | 'green' | 'red' | 'amber';
+  formatValue?: (v: string | number) => string;
+  className?: string;
 }
 
-export const KpiCard: React.FC<KpiCardProps> = ({ label, value }) => (
-  <div
-    className="kpi-card"
-    style={{ border: '1px solid #ccc', padding: '8px', borderRadius: '4px' }}
-  >
-    <h3 style={{ margin: 0, fontSize: '1rem' }}>{label}</h3>
-    <p style={{ margin: 0, fontSize: '1.2rem', fontWeight: 'bold' }}>{value}</p>
-  </div>
-);
+export const KpiCard: React.FC<KpiCardProps> = ({
+  label,
+  value,
+  helpText,
+  colorScheme = 'default',
+  formatValue,
+  className,
+}) => {
+  const displayValue = formatValue ? formatValue(value) : String(value);
+  const schemeClass = styles[`accent-${colorScheme}` as keyof typeof styles];
+  const classes = [styles.card, schemeClass, className]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div tabIndex={0} className={classes}>
+      <div className={styles.label}>{label}</div>
+      <div className={styles.value}>{displayValue}</div>
+      {helpText && <div className={styles.helpText}>{helpText}</div>}
+    </div>
+  );
+};
 
 export default KpiCard;

--- a/src/components/common/RunCard.module.css
+++ b/src/components/common/RunCard.module.css
@@ -1,0 +1,65 @@
+.card {
+  padding: 12px;
+  background: #ffffff;
+  border-radius: 4px;
+  border-left: 4px solid var(--status-color, #9ca3af);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+  margin: 8px 0;
+}
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.title {
+  margin: 0;
+  font-size: 1rem;
+}
+.statusText {
+  text-transform: capitalize;
+  font-size: 0.875rem;
+  color: #6b7280;
+}
+.progressBar {
+  position: relative;
+  height: 4px;
+  background: #e5e7eb;
+  overflow: hidden;
+  border-radius: 2px;
+  margin-top: 8px;
+}
+.progressIndicator {
+  position: absolute;
+  left: -40%;
+  top: 0;
+  bottom: 0;
+  width: 40%;
+  background: var(--status-color, #9ca3af);
+  animation: progress 1s infinite;
+}
+@keyframes progress {
+  0% {
+    left: -40%;
+  }
+  100% {
+    left: 100%;
+  }
+}
+.progressDetails {
+  display: flex;
+  gap: 8px;
+  font-size: 0.75rem;
+  margin-top: 4px;
+}
+.status-idle {
+  --status-color: #9ca3af;
+}
+.status-running {
+  --status-color: #f59e0b;
+}
+.status-complete {
+  --status-color: #10b981;
+}
+.status-error {
+  --status-color: #ef4444;
+}

--- a/src/components/common/RunCard.tsx
+++ b/src/components/common/RunCard.tsx
@@ -1,29 +1,51 @@
 import React from 'react';
+import styles from './RunCard.module.css';
 
-interface RunCardProps {
+export type RunStatus = 'idle' | 'running' | 'complete' | 'error';
+
+export interface RunCardProps {
   title: string;
-  status: 'idle' | 'running' | 'complete' | 'error';
+  status: RunStatus;
+  progress?: { iter?: number; error?: number };
+  className?: string;
 }
 
-const statusColor: Record<RunCardProps['status'], string> = {
-  idle: '#ccc',
-  running: 'orange',
-  complete: 'green',
-  error: 'red',
-};
+export const RunCard: React.FC<RunCardProps> = ({
+  title,
+  status,
+  progress,
+  className,
+}) => {
+  const classes = [styles.card, styles[`status-${status}`], className]
+    .filter(Boolean)
+    .join(' ');
+  const role = status === 'error' ? 'alert' : status === 'running' ? 'status' : undefined;
 
-export const RunCard: React.FC<RunCardProps> = ({ title, status }) => (
-  <div
-    className="run-card"
-    style={{
-      border: `2px solid ${statusColor[status]}`,
-      padding: '8px',
-      borderRadius: '4px',
-    }}
-  >
-    <h4 style={{ margin: 0 }}>{title}</h4>
-    <p style={{ margin: 0 }}>{status}</p>
-  </div>
-);
+  return (
+    <div className={classes} role={role} aria-live={status === 'running' ? 'polite' : undefined}>
+      <div className={styles.header}>
+        <h4 className={styles.title}>{title}</h4>
+        <span className={styles.statusText}>{status}</span>
+      </div>
+      {status === 'running' && (
+        <>
+          <div className={styles.progressBar}>
+            <div className={styles.progressIndicator} />
+          </div>
+          {progress && (
+            <div className={styles.progressDetails}>
+              {progress.iter !== undefined && (
+                <span>Iter {progress.iter}</span>
+              )}
+              {progress.error !== undefined && (
+                <span>Error {progress.error.toFixed(4)}</span>
+              )}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+};
 
 export default RunCard;

--- a/src/components/common/__tests__/DataQualityBanner.test.tsx
+++ b/src/components/common/__tests__/DataQualityBanner.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { DataQualityBanner } from '../DataQualityBanner';
+import styles from '../DataQualityBanner.module.css';
+
+describe('DataQualityBanner', () => {
+  it('renders correct variant class', () => {
+    const { container } = render(
+      <DataQualityBanner variant="warning" message="Be careful" />
+    );
+    const banner = container.firstChild as HTMLElement;
+    expect(banner).toHaveClass(styles.warning);
+    expect(banner).toHaveAttribute('role', 'status');
+  });
+
+  it('role changes for error', () => {
+    render(<DataQualityBanner variant="error" message="Boom" />);
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+
+  it('dismiss click calls onClose', () => {
+    const onClose = vi.fn();
+    render(
+      <DataQualityBanner message="Info" dismissible onClose={onClose} />
+    );
+    fireEvent.click(screen.getByLabelText(/Close banner/i));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/src/components/common/__tests__/HyperparamSlider.test.tsx
+++ b/src/components/common/__tests__/HyperparamSlider.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { HyperparamSlider } from '../HyperparamSlider';
+
+describe('HyperparamSlider', () => {
+  it('updates value via keyboard and calls onChange', () => {
+    const onChange = vi.fn();
+    render(
+      <HyperparamSlider label="Test" value={0} min={0} max={10} step={1} onChange={onChange} />
+    );
+    const slider = screen.getByRole('slider');
+    fireEvent.keyDown(slider, { key: 'ArrowRight' });
+    fireEvent.change(slider, { target: { value: '1' } });
+    expect(onChange).toHaveBeenCalledWith(1);
+  });
+
+  it('displays formatted value', () => {
+    render(
+      <HyperparamSlider
+        label="LR"
+        value={0.1234}
+        precision={2}
+        suffix="%"
+        onChange={() => {}}
+      />
+    );
+    expect(screen.getByText('LR:')).toBeInTheDocument();
+    expect(screen.getByText('0.12%')).toBeInTheDocument();
+  });
+});

--- a/src/components/common/__tests__/KpiCard.test.tsx
+++ b/src/components/common/__tests__/KpiCard.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { KpiCard } from '../KpiCard';
+import styles from '../KpiCard.module.css';
+
+describe('KpiCard', () => {
+  it('renders label and value', () => {
+    render(<KpiCard label="Accuracy" value="95%" />);
+    expect(screen.getByText('Accuracy')).toBeInTheDocument();
+    expect(screen.getByText('95%')).toBeInTheDocument();
+  });
+
+  it('applies colorScheme class and formats value', () => {
+    const { container } = render(
+      <KpiCard
+        label="Score"
+        value={1.2345}
+        colorScheme="blue"
+        formatValue={(v) => Number(v).toFixed(2)}
+      />
+    );
+    expect(screen.getByText('1.23')).toBeInTheDocument();
+    expect(container.firstChild).toHaveClass(styles['accent-blue']);
+  });
+});

--- a/src/components/common/__tests__/RunCard.test.tsx
+++ b/src/components/common/__tests__/RunCard.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { RunCard } from '../RunCard';
+import styles from '../RunCard.module.css';
+
+describe('RunCard', () => {
+  it('applies status color', () => {
+    const { container } = render(<RunCard title="Run" status="running" />);
+    expect(container.firstChild).toHaveClass(styles['status-running']);
+  });
+
+  it('shows progress only when running', () => {
+    const { container } = render(
+      <RunCard title="Run" status="running" progress={{ iter: 1, error: 0.1 }} />
+    );
+    expect(screen.getByText(/Iter 1/)).toBeInTheDocument();
+    expect(container.querySelector(`.${styles.progressBar}`)).not.toBeNull();
+
+    const { container: idleContainer } = render(
+      <RunCard title="Run" status="idle" />
+    );
+    expect(idleContainer.querySelector(`.${styles.progressBar}`)).toBeNull();
+  });
+});

--- a/src/pages/ModelLab.spec.tsx
+++ b/src/pages/ModelLab.spec.tsx
@@ -1,9 +1,13 @@
 import React from 'react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
 import { MemoryRouter } from 'react-router-dom';
+vi.mock('@/lib/brain/train', () => ({ trainBrain: vi.fn() }));
+vi.mock('../components/common/CompositeChart.tsx', () => ({
+  CompositeChart: () => <div />, default: () => <div />,
+}), { virtual: true });
 import trainingReducer from '@/features/training/trainingSlice';
 import datasetsReducer from '@/features/datasets/datasetsSlice';
 import ModelLab from './ModelLab';

--- a/src/pages/ModelLab.tsx
+++ b/src/pages/ModelLab.tsx
@@ -1,9 +1,7 @@
 import React, { useState } from 'react';
-import {
-  DataQualityBanner,
-  HyperparamSlider,
-  RunCard,
-} from '../components/common';
+import { DataQualityBanner } from '../components/common/DataQualityBanner';
+import { HyperparamSlider } from '../components/common/HyperparamSlider';
+import { RunCard } from '../components/common/RunCard';
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import {
   selectTrainingStatus,
@@ -51,29 +49,35 @@ export const ModelLab: React.FC = () => {
   return (
     <div className="model-lab-page">
       <DataQualityBanner message={open.length ? 'Data loaded' : 'No data'} />
-      <HyperparamSlider
-        label="Learning Rate"
-        value={learningRate}
-        min={0}
-        max={1}
-        step={0.01}
-        onChange={setLearningRate}
-      />
-      <HyperparamSlider
-        label="Iterations"
-        value={iterations}
-        min={100}
-        max={5000}
-        step={100}
-        onChange={setIterations}
-      />
+      <div
+        style={{
+          padding: '16px',
+          border: '1px solid #e5e7eb',
+          borderRadius: '8px',
+          marginBottom: '16px',
+        }}
+      >
+      <h3 style={{ margin: '0 0 8px 0', fontSize: '1rem' }}>Hyperparameters</h3>
+        <HyperparamSlider
+          label="Learning Rate"
+          value={learningRate}
+          min={0}
+          max={1}
+          step={0.01}
+          precision={4}
+          onChange={setLearningRate}
+        />
+        <HyperparamSlider
+          label="Iterations"
+          value={iterations}
+          min={100}
+          max={5000}
+          step={100}
+          onChange={setIterations}
+        />
+      </div>
       <button onClick={startTraining}>Train Model</button>
-      {status === 'running' && progress ? (
-        <div aria-live="polite">
-          Iter {progress.iter} Error {progress.error.toFixed(4)}
-        </div>
-      ) : null}
-      <RunCard title="Latest Run" status={status} />
+      <RunCard title="Latest Run" status={status} progress={progress} />
     </div>
   );
 };

--- a/src/pages/Overview.spec.tsx
+++ b/src/pages/Overview.spec.tsx
@@ -1,15 +1,20 @@
 import React from 'react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { configureStore } from '@reduxjs/toolkit';
 import { MemoryRouter } from 'react-router-dom';
+vi.mock('@/lib/brain/train', () => ({ trainBrain: vi.fn() }));
+vi.mock('../components/common/CompositeChart.tsx', () => ({
+  CompositeChart: () => <div data-testid="chart" />,
+  default: () => <div data-testid="chart" />,
+}), { virtual: true });
 import trainingReducer from '@/features/training/trainingSlice';
 import datasetsReducer from '@/features/datasets/datasetsSlice';
 import Overview from './Overview';
 
 describe('Overview page', () => {
-  it('renders CompositeChart', () => {
+  it('renders warning banner when no results', () => {
     const store = configureStore({
       reducer: { training: trainingReducer, datasets: datasetsReducer },
       preloadedState: {
@@ -39,6 +44,10 @@ describe('Overview page', () => {
         </Provider>
       </MemoryRouter>
     );
-    expect(screen.getByText(/No training results yet/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        /No training results yet. Run a model in Model Lab to see metrics and charts./i
+      )
+    ).toBeInTheDocument();
   });
 });

--- a/src/pages/Overview.tsx
+++ b/src/pages/Overview.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
-import {
-  CompositeChart,
-  KpiCard,
-  DataQualityBanner,
-} from '../components/common';
+import { CompositeChart } from '../components/common/CompositeChart';
+import { KpiCard } from '../components/common/KpiCard';
+import { DataQualityBanner } from '../components/common/DataQualityBanner';
 import { useAppSelector } from '@/store/hooks';
 import { selectPredictions, selectMetrics } from '@/features/training/trainingSlice';
 import {
@@ -33,15 +31,24 @@ export const Overview: React.FC = () => {
           <section className="kpi-section">
             <KpiCard
               label="MSE"
-              value={metrics?.mse?.toFixed(4) ?? '-'}
+              value={metrics?.mse ?? '-'}
+              formatValue={(v) =>
+                typeof v === 'number' ? v.toFixed(4) : String(v)
+              }
             />
             <KpiCard
               label="MAE"
-              value={metrics?.mae?.toFixed(4) ?? '-'}
+              value={metrics?.mae ?? '-'}
+              formatValue={(v) =>
+                typeof v === 'number' ? v.toFixed(4) : String(v)
+              }
             />
             <KpiCard
               label="MAPE"
-              value={metrics?.mape?.toFixed(2) ?? '-'}
+              value={metrics?.mape ?? '-'}
+              formatValue={(v) =>
+                typeof v === 'number' ? v.toFixed(2) : String(v)
+              }
             />
           </section>
           <CompositeChart
@@ -51,7 +58,10 @@ export const Overview: React.FC = () => {
           />
         </>
       ) : (
-        <DataQualityBanner message="No training results yet" />
+        <DataQualityBanner
+          variant="warning"
+          message="No training results yet. Run a model in Model Lab to see metrics and charts."
+        />
       )}
     </div>
   );

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -57,6 +57,25 @@ HTMLCanvasElement.prototype.getContext = vi.fn(() => ({
   stroke: vi.fn(),
 }));
 
+// Stub node-canvas and gl to avoid native bindings
+vi.mock('canvas', () => ({
+  Canvas: class {},
+  Image: class {},
+  createCanvas: () => document.createElement('canvas'),
+}), { virtual: true });
+vi.mock('gl', () => ({}), { virtual: true });
+vi.mock('chart.js', () => ({
+  Chart: class {},
+  register: () => {},
+  CategoryScale: class {},
+  LinearScale: class {},
+  PointElement: class {},
+  LineElement: class {},
+  Title: class {},
+  Tooltip: class {},
+  Legend: class {},
+}), { virtual: true });
+
 // Stub out react-chartjs-2 components with simple div placeholders
 vi.mock('react-chartjs-2', () => {
   const ChartStub = ({ data }: { data?: unknown }) =>


### PR DESCRIPTION
## Summary
- style KPI card with color schemes, value formatting, and keyboard focus
- add variant-driven data quality banner with optional dismissal
- implement accessible hyperparameter slider and run card with progress

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68affb441a88832a9ccc33c2a4cd49d9